### PR TITLE
Updated mailing list notification addresses

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -6,3 +6,8 @@ github:
     - community
     - comdev
     - hugo
+
+notifications:
+  commits:      commits@community.apache.org
+  issues:       dev@community.apache.org
+  pullrequests: dev@community.apache.org


### PR DESCRIPTION
https://gitbox.apache.org/schemes.cgi?comdev-site shows that our notifications are sent to *@comdev.a.o however the mailing lists are available at *@community.a.o