### PR TITLE
Remove reference to Apache Labs and projects-new

### DIFF
--- a/source/newbiefaq.md
+++ b/source/newbiefaq.md
@@ -40,10 +40,9 @@ the information they're looking for. Please ask questions or give us suggestions
 There are over 200 separate projects and communities hosted at The Apache Software Foundation. We have
 four classes, or types, of project (in terms of their community; not in terms of technology):
 
-   * [Top Level Projects](https://projects.apache.org): (TLP) these are projects with healthy communities and active development; and a supported [listing by technologies](https://projects.apache.org/) and [experimental listing of projects](https://projects-new.apache.org/).
+   * [Top Level Projects](https://projects.apache.org): (TLP) these are projects with healthy communities and active development; and a supported [listing by technologies](https://projects.apache.org/) of projects.
    * [Incubating Projects](https://incubator.apache.org): these are projects that have yet to build a sustainable community, but
 have active development and are moving towards graduating to become TLPs.
-   * [Labs](https://labs.apache.org): these are experiments existing committers are carrying out.
    * [Attic](https://attic.apache.org): these are end-of-life projects that are no longer receiving active
 development, but may still be useful.
 


### PR DESCRIPTION
Since Apache Labs has been moved to the Attic and projects-new.apache.org no longer exist, this PR seeks to remove those references.