### PR TITLE
New Committer updates based on #41

### DIFF
--- a/source/newcommitter.md
+++ b/source/newcommitter.md
@@ -298,8 +298,8 @@ This is the followup email after the new committer has accepted the invitation.
       https://www.apache.org/foundation/policies/conduct.html
     
     [PROJECT should insert its own guidelines here; if none are available,
-     the Apache Forrest guidelines are available as a template.
-      https://forrest.apache.org/guidelines.html.]
+     the Apache Forrest guidelines are available as a template.]
+      https://forrest.apache.org/guidelines.html
     
     Yours,
     The Apache [PROJECT] PMC

--- a/source/newcommitter.md
+++ b/source/newcommitter.md
@@ -110,7 +110,7 @@ becomes obvious that we should invite them. This encourages them and keeps
 them enthusiastic. If we leave it too long, then we risk them becoming
 disillusioned.
 
-On the `@private` list we can each say exactly what we feel about each person,
+On the `private@` list we can each say exactly what we feel about each person,
 with no holds barred. Keep the discussion concise. The praise part can
 be done later in public. Keep in mind, however, that if the member becomes
 a PMC member later, they will have access to this discussion.
@@ -131,7 +131,7 @@ After a positive result, record the result on the PMC list with a [RESULT][VOTE]
 and then invite the candidate. We give candidates a chance to decline committership in private. They
 can post a reply to the PMC mailing list.
 
-After we reach a decision on the `@private` list, and after the steps above, we
+After we reach a decision on the `private@` list, and after the steps above, we
 announce the new committer on the `dev` list. We can then each follow up with
 our praise in public.
 
@@ -295,7 +295,7 @@ This is the followup email after the new committer has accepted the invitation.
 
     Just as before you became a committer, participation in any ASF community
     requires adherence to the ASF Code of Conduct:
-      https://www.apache.org/foundation/policies/conduct.html.
+      https://www.apache.org/foundation/policies/conduct.html
     
     [PROJECT should insert its own guidelines here; if none are available,
      the Apache Forrest guidelines are available as a template.

--- a/source/newcommitter.md
+++ b/source/newcommitter.md
@@ -244,7 +244,7 @@ sent after a positive result from the vote for a new committer.
         to notify the Apache [Project] and choose a 
         unique Apache ID. Look to see if your preferred 
         ID is already taken at 
-        https://people.apache.org/committer-index.html.     
+        https://people.apache.org/committer-index.html
         This will allow the Secretary to notify the PMC 
         when your iCLA has been recorded.
 


### PR DESCRIPTION
I can't make updates in #41 as the merge branch for PR is from a [different repository](https://github.com/cottage14/comdev-site/tree/patch-26) and edits from maintainers were not allowed.
Thus I am incorporating these changes here based on #41. The changes from remote branch `patch-26` from [cottage14/patch-26](https://github.com/cottage14/comdev-site/tree/patch-26) is merged at local `cottage14-patch-26` to persevere the commit history.

Credits: Thank you @cottage14 for the updates. 
And thank you @clr-apache for the inputs.