### PR TITLE
Send GitBox notifications to separate list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -9,5 +9,5 @@ github:
 
 notifications:
   commits:      commits@community.apache.org
-  issues:       dev@community.apache.org
-  pullrequests: dev@community.apache.org
+  issues:       notifications@community.apache.org
+  pullrequests: notifications@community.apache.org


### PR DESCRIPTION
This change redirects GitBox issue/pull request activity to a separate
mailing list to avoid spamming the dev@ list. The new notifications@
list must be created by the ComDev PMC before accepting/merging this PR.

The justification for this change is:

1. These automated notices are redundant if somebody is already watching
   the relevant notices for the repo on GitHub. So, sending these to
   another list allows users more flexibility in receiving them or not,
   and whether they prefer to receive them as an email or as a notice
   directly from watching the repo in GitHub.
2. These automated notices spam the dev@ list which many more people
   follow for the human discussions here on community development across
   the ASF. Sending them to another list ensures the dev@ list is
   reserved for human-to-human conversations, and keeps people from
   unsubscribing and connected to the community due to frustration with
   spam.