### PR TITLE
[Improved] Added ASF logo as the comdev site logo

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -50,12 +50,17 @@
           border-top: solid #ddd 1px;
           margin-top:1em;
       }
+      .navbar-brand img {
+          height: 50px;
+      }
   </style>
 </head>
 
 <body>
   <header class="navbar navbar-expand-lg navbar-dark bg-dark fixed-top">
     <!-- <a class="navbar-brand" href="/">Apache Community Development Project</a> -->
+    <div class="container">
+      <a class="navbar-brand" href="/"><img src="https://svn.apache.org/repos/asf/comdev/project-logos/originals/foundation.svg" alt="Apache Software Foundation"></a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#mainNavbar" aria-controls="mainNavbar" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>
@@ -162,13 +167,14 @@
             </div>
           </li>
         </ul>
-      </div>>
+      </div>
     </div><!--/.navbar-collapse -->
+    </div><!--container div-->
   </header>
 
   <main class="cd-main" id="content" role="main">
     <div class="container">
-      <section id="content" class="row">
+      <section id="content" class="row mt-3">
         <div class="col-md-9">
           <h3 class="mt-3 text-muted">The Apache Software Foundation</h3>
         </div>


### PR DESCRIPTION
- Added a container div to align the header items to the center of the screen
- Added margin to the main content section so as to allow separation from the header
- Added inline height to the logo image.