### PR TITLE
[Fixed]: Mis-allignment issue on the 'guide to being a mentor page'

### DIFF
--- a/source/guide-to-being-a-mentor.md
+++ b/source/guide-to-being-a-mentor.md
@@ -15,8 +15,9 @@ submit ideas via JIRA (if your project does not use JIRA you can [use the Comdev
 * Add an issue to JIRA (if your project does not use JIRA you can [use the Comdev Issue Tracker For GSoC Tasks](use-the-comdev-issue-tracker-for-gsoc-tasks.html)
   * Add sub-tasks if necessary
 * Label the main issue with "*mentor*" (these will show up at the [ASF-wide list of issues](https://issues.apache.org/jira/issues?jql=labels%20in%20(gsoc2022)%20AND%20labels%20in%20(mentor,%20Mentor)))
-* Label the main issue with "*gsoc2022*" if appropriate (these will show up at <https://s.apache.org/gsoc2022ideas>)
-* <div class="card border-success mb-3">
+* Label the main issue with "*gsoc2022*" if appropriate (these will show up at [GSoC 2022 Ideas](https://s.apache.org/gsoc2022ideas))
+
+<div class="card border-success mb-3">
   <div class="card-header">Size of project</div>
   <div class="card-body text-success">
     <p class="card-text">Starting this year there are 2 types of projects available.<br> Please put "<em>full-time</em>" label for ~350 hours project and<br> "<em>part-time</em>" label for ~175 hours project</p>


### PR DESCRIPTION
- fixed the indentation for the div that was causing the issue
- Updated the link text for the GSoC ideas page link