### PR TITLE
[Fixed]: Updated the broken link for the ASF intro slide

### DIFF
--- a/source/guide-to-being-a-mentor.md
+++ b/source/guide-to-being-a-mentor.md
@@ -15,8 +15,9 @@ submit ideas via JIRA (if your project does not use JIRA you can [use the Comdev
 * Add an issue to JIRA (if your project does not use JIRA you can [use the Comdev Issue Tracker For GSoC Tasks](use-the-comdev-issue-tracker-for-gsoc-tasks.html)
   * Add sub-tasks if necessary
 * Label the main issue with "*mentor*" (these will show up at the [ASF-wide list of issues](https://issues.apache.org/jira/issues?jql=labels%20in%20(gsoc2022)%20AND%20labels%20in%20(mentor,%20Mentor)))
-* Label the main issue with "*gsoc2022*" if appropriate (these will show up at <https://s.apache.org/gsoc2022ideas>)
-* <div class="card border-success mb-3">
+* Label the main issue with "*gsoc2022*" if appropriate (these will show up at [GSoC 2022 Ideas](https://s.apache.org/gsoc2022ideas))
+
+<div class="card border-success mb-3">
   <div class="card-header">Size of project</div>
   <div class="card-body text-success">
     <p class="card-text">Starting this year there are 2 types of projects available.<br> Please put "<em>full-time</em>" label for ~350 hours project and<br> "<em>part-time</em>" label for ~175 hours project</p>

--- a/source/links.md
+++ b/source/links.md
@@ -25,6 +25,6 @@ authors for more information or questions. General discussion on the dev@communi
   [1]: https://producingoss.com/
   [2]: https://grep.codeconsult.ch/2009/03/30/the-asf-is-the-switzerland-of-open-source/
   [3]: https://psteitz.blogspot.ch/2011/11/thinking-together.html
-  [4]: https://www.apachecon.com/eu2007/materials/asf-intro-slides-eilebrecht.pdf
+  [4]: http://archive.apachecon.com/eu2007/materials/asf-intro-slides-eilebrecht.pdf
   [5]: http://theapacheway.com/
   [6]: https://delicious.com/bdelacretaz/opendevelopment


### PR DESCRIPTION
Steps to regenerate:
1. Navigate to https://community.apache.org/links.html
2. Click on the "Behind the Scenes of the Apache Software Foundation" link.