### PR TITLE
[Improved]: Moved mentor specific instructions from GSoC main page to the mentor's guide

### DIFF
--- a/source/gsoc.md
+++ b/source/gsoc.md
@@ -31,7 +31,6 @@ filtering using the "*gsoc2023*" label, this allows you to narrow down the list
 to the projects you are interested in.<br/>
 Or simply use this link https://issues.apache.org/jira/issues/?jql=labels+%3D+gsoc2023
 * If you do not see any interesting projects from the proposed ideas, we encourage you to contact one of the Apache Project's mailing list and propose a new idea. But these ideas have to be vetted on the project dev list. The ASF does not encourage and will not respond to your personal new open source project ideas which are unrelated to any Apache projects.
-* Please NOTE `Ideas list` is manually updated by GSoC admins, please ping mentors (at) community.apache.org if the page is not being updated .. :))
 
 <a name="GSoC-ApplyingforGSoC"></a>
 ### Applying for GSoC
@@ -123,36 +122,6 @@ students will usually be interacting with just one of these communities.
 Each of the proposed subjects (link to be provided if we are confirmed as a
 mentoring organisation) applies to a single ASF project. You will need to
 engage with that project community.
-
-<a name="GSoC-ProspectiveASFmentors:readthis"></a>
-<a name="formentors"></a>
-# Prospective ASF mentors: read this
-
-We are looking for as many interesting projects as we can come up with. For
-more info about mentoring, please read our [guide to being a mentor](guide-to-being-a-mentor.html)
-.
-
-Prospective mentors must join the mentors@community.apache.org mailing list,
-this is where mentor specific issues are dealt with, and where
-announcements will be made. If you want to track the program
-administration you should subscribe to dev@community.apache.org.
-
-Once the ASF is confirmed as a mentoring organisation mentors must register
-with the GSoC webapp, and request to become a mentor for the ASF
-organization. Make sure that the email address you use for that (it's often
-your @gmail.com address by default) is '''registered as a mail alias for your Apache account at (https://id.apache.org)''' so that we can match it to your ASF account.
-
-All ASF projects are invited to submit their ideas to their issue tracker,
-please be sure to add the labels "*gsoc2023*" and "*mentor*" so that we can
-automatically include them in our list of subjects. If your project does
-not use JIRA please contact dev@community.apache.org.
-
-<div class="card border-success mb-3">
-  <div class="card-header">Size of project</div>
-  <div class="card-body text-success">
-    <p class="card-text">Starting this year there are 2 types of projects available.<br> Please put "<em>full-time</em>" label for ~350 hours project and<br> "<em>part-time</em>" label for ~175 hours project</p>
-  </div>
-</div>
 
 <a name="GSoC-ASFGSoCTimeline"></a>
 # ASF GSoC 2023 Timeline

--- a/source/guide-to-being-a-mentor.md
+++ b/source/guide-to-being-a-mentor.md
@@ -16,6 +16,7 @@ submit ideas via JIRA (if your project does not use JIRA you can [use the Comdev
   * Add sub-tasks if necessary
 * Label the main issue with "*mentor*" (these will show up at the [ASF-wide list of issues](https://issues.apache.org/jira/issues?jql=labels%20in%20(gsoc2023)%20AND%20labels%20in%20(mentor,%20Mentor)))
 * Label the main issue with "*gsoc2023*" if appropriate (these will show up at [GSoC 2023 Ideas](https://s.apache.org/gsoc2023ideas))
+* Please NOTE Ideas list is manually updated by GSoC admins, please ping mentors (at) community.apache.org if the page is not being updated .. :))
 
 <div class="card border-success mb-3">
   <div class="card-header">Size of project</div>

--- a/source/guide-to-being-a-mentor.md
+++ b/source/guide-to-being-a-mentor.md
@@ -77,14 +77,21 @@ share them with other projects (mail `dev@community.apache.org`).
 <a name="guidetobeingamentor-Stayingintouch"></a>
 # Staying in touch
 
-All mentors *must* subscribe to `mentors@community.apache.org`, our list for
-coordinating mentor activities. 
+All mentors/prospective mentors **must** subscribe to `mentors@community.apache.org`, our list for
+coordinating mentor activities.
+This is where mentor specific issues are dealt with, and where announcements will be made.
 
 We only accept subscriptions to mentors@ from addresses known to
 belong to ASF committers, so please use your @apache.org address to
 subscribe if possible, or at least an address that we can match to your
 `@apache.org` address via the ASF's private/committers/info or
 private/committers/MailAlias.txt data.
+
+Once the ASF is confirmed as a mentoring organisation mentors must register 
+with the GSoC webapp, and request to become a mentor for the ASF organization. 
+Make sure that the email address you use for that (it’s often your @gmail.com address by default) 
+is ‘‘‘registered as a mail alias for your Apache account at (https://id.apache.org)’’’ 
+so that we can match it to your ASF account.
 
 If you are interested in mentor programme administration please also
 subscribe to `dev@community.apache.org`.

--- a/source/guide-to-being-a-mentor.md
+++ b/source/guide-to-being-a-mentor.md
@@ -10,13 +10,12 @@ ASF mentoring programme. Any Apache member and experienced committers can
 submit ideas via JIRA (if your project does not use JIRA you can [use the Comdev Issue Tracker For GSoC Tasks](use-the-comdev-issue-tracker-for-gsoc-tasks.html). We are looking for as many interesting projects as we can come up with. 
 
 <a name="guidetobeingamentor-Summary"></a>
-## Summary
+## Important Steps
 
 * Add an issue to JIRA (if your project does not use JIRA you can [use the Comdev Issue Tracker For GSoC Tasks](use-the-comdev-issue-tracker-for-gsoc-tasks.html)
   * Add sub-tasks if necessary
 * Label the main issue with "*mentor*" (these will show up at the [ASF-wide list of issues](https://issues.apache.org/jira/issues?jql=labels%20in%20(gsoc2023)%20AND%20labels%20in%20(mentor,%20Mentor)))
 * Label the main issue with "*gsoc2023*" if appropriate (these will show up at [GSoC 2023 Ideas](https://s.apache.org/gsoc2023ideas))
-* Please NOTE Ideas list is manually updated by GSoC admins, please ping mentors (at) community.apache.org if the page is not being updated .. :))
 
 <div class="card border-success mb-3">
   <div class="card-header">Size of project</div>
@@ -24,6 +23,8 @@ submit ideas via JIRA (if your project does not use JIRA you can [use the Comdev
     <p class="card-text">Starting this year there are 2 types of projects available.<br> Please put "<em>full-time</em>" label for ~350 hours project and<br> "<em>part-time</em>" label for ~175 hours project</p>
   </div>
 </div>
+
+Please NOTE Ideas list is manually updated by GSoC admins, please ping mentors (at) community.apache.org if the page is not being updated .. :))
 
 <a name="guidetobeingamentor-Detail"></a>
 ## Details


### PR DESCRIPTION
This is to hide the mentor's list information from the students and avoid confusion, wherein the students end up subscribing and sending emails to the mentor's list.

Most information was already available on the page, I just added the missing parts.