### PR TITLE
Remove references to helpwanted

### DIFF
--- a/source/_index.md
+++ b/source/_index.md
@@ -103,6 +103,4 @@ in the specific Apache projects that interest you.
         about Apache at <a href="https://lists.apache.org/list.html?dev@community.apache.org:lte=3M:">dev@community.apache.org</a>.</p>
 </div>
 
-<div class="container" type="helpwanted" project="comdev" description="Community Development"></div>
-<script src="https://helpwanted.apache.org/widget.js" type="text/javascript"></script>
-<!-- dummy change (42) to test asf-site commit -->
+

--- a/source/about/__index.md
+++ b/source/about/__index.md
@@ -48,7 +48,6 @@ ComDev manages a number of helpful tools for finding your way around.
 
   - The [Apache Projects Directory](https://projects.apache.org/) lists all our software projects.  [See the Project Directory **code**](https://projects.apache.org/about.html) and the JSON data feeds available.
   - [Apache Committers Phone Book](https://home.apache.org/) lists all individual Apache committers.  [See the Phonebook **code**](https://home.apache.org/phonebook-about.html).
-  - Some projects [ask for help](https://helpwanted.apache.org/) with easy-to-get-started tasks or bug fixes for newcomers.  [See the HelpWanted **code**](https://svn.apache.org/viewvc/comdev/helpwanted.apache.org/).
   - The [Project Reporting Tool](https://reporter.apache.org/) (requires login) helps Apache PMCs create quarterly board reports.  [See the Reporter **code**](https://svn.apache.org/repos/asf/comdev/projects.apache.org/).
   - The [ComDev Wiki](https://cwiki.apache.org/confluence/display/COMDEV/ComDev+Wiki) is also available for scratch or experimental work, although most permanent content should be here in the website.
 

--- a/source/newbiefaq.md
+++ b/source/newbiefaq.md
@@ -152,8 +152,6 @@ inspiration about how you might be able to help the project community. If
 you see an issue you would like to tackle, it's time to join the project's
 mailing list and get started.
 
-Some projects also use our [Help Wanted! system](https://helpwanted.apache.org/).
-
 <a name="NewbieFAQ-HowdoIgetinvolvedwithanApacheproject?"></a>
 ## How do I get involved with an Apache project?
 
@@ -245,7 +243,6 @@ that help you navigate the ASF.
 
   - The [Apache Projects Directory][9] lists all our software technologies, and you can learn [how it works][10] and what JSON data feeds are available.
   - [Home.apache.org][11] serves as a telephone directory of all Apache committers.  
-  - Some projects [ask for help][12] with easy-to-get-started tasks or bug fixes for newcomers. You can see the [code that runs the HelpWanted site][13].
   - Apache committers can log in to the [Project Reporting Tool][14] that helps PMCs create quarterly board reports; you can [see the code that does this][15].
   - A [ComDev Wiki][wiki] is also available for scratch or experimental work, although most permanent content should be here in the website.
 
@@ -265,8 +262,6 @@ can submit bug reports related to any of our services or websites.
   [9]: https://projects.apache.org/
   [10]: https://projects.apache.org/about.html
   [11]: https://home.apache.org/
-  [12]: https://helpwanted.apache.org/
-  [13]: https://svn.apache.org/viewvc/comdev/helpwanted.apache.org/
   [14]: https://reporter.apache.org/
   [15]: https://svn.apache.org/repos/asf/comdev/reporter.apache.org/
 

--- a/source/newcomers/__index.md
+++ b/source/newcomers/__index.md
@@ -10,7 +10,6 @@ you stepping up to help out.
 
   * [Where do I start?](/gettingStarted/101.html) - a guide to your first engagement with an Apache project
   * [How should I behave?](/contributors/etiquette) - etiquette and codes of conduct at Apache
-  * [What can I work on?](https://helpwanted.apache.org) - suggested tasks you can start working on today 
   * [Mentoring Programme](/mentoringprogramme.html) - an introduction to our mentoring programme
       * [Mentoring in formal education](/mentorprogrammeformaleducation.html) - how to engage your students in open source
       * [Local Mentors Programme](/localmentors.html) - Find ASF people who live near you
@@ -38,5 +37,4 @@ list. Send an email to
 [dev-subscribe@community.apache.org](mailto:dev-subscribe@community.apache.org). Once subscribed you can send your questions or feedback to
 [dev@community.apache.org](mailto:dev@community.apache.org).
 
-<div style="width: 700px;" type="helpwanted" project="comdev"  description="Community Development"></div>
-<script src="https://helpwanted.apache.org/widget.js" type="text/javascript"></script>
+


### PR DESCRIPTION
The helpwanted site hasn't had useful content on it in years. It was a great idea at the time, but it only works if people use it. Removing from our site until such time as there's actually content there, if ever.