### PR TITLE
Remove some things we don't actually do

### DIFF
--- a/source/about/__index.md
+++ b/source/about/__index.md
@@ -18,8 +18,7 @@ provides a wide array of information, [FAQs](/newbiefaq.html), and help to newco
 
 ### Mentoring for Projects
 - [Incubator Mentors](https://incubator.apache.org/guides/mentor.html) - Many folks here are IPMC members or mentors, too
-- TLPs and sub-projects
-- Project Community Ombudsman  - get community advice on dev@community
+- Get community advice on dev@community
 
 ### Education + Outreach
 - [ApacheCon](https://apachecon.com/)
@@ -28,16 +27,10 @@ provides a wide array of information, [FAQs](/newbiefaq.html), and help to newco
 - Event Representatives (booth coverage, etc.)
 - [Speaker Resources](/speakers/)
 - [Stock Presentations](/speakers/slides.html)
-- Apache Ambassadors
 
 ### Diversity
 - [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html)
 - Surveys
-- Women in Apache events (e.g., ApacheCon Luncheon, etc.)
-- ApacheCon family activities (e.g., kids programming challenge,
-  babysitting services, etc.)
-- ApacheCon diversity scholarship (e.g., free registration, access to
-  tutorials, etc.)
 
 ### Conference Travel Assistance
 - [TAC - Travel Assistance Committee](https://www.apache.org/travel)
@@ -51,20 +44,12 @@ ComDev manages a number of helpful tools for finding your way around.
   - The [Project Reporting Tool](https://reporter.apache.org/) (requires login) helps Apache PMCs create quarterly board reports.  [See the Reporter **code**](https://svn.apache.org/repos/asf/comdev/projects.apache.org/).
   - The [ComDev Wiki](https://cwiki.apache.org/confluence/display/COMDEV/ComDev+Wiki) is also available for scratch or experimental work, although most permanent content should be here in the website.
 
-The ComDev PMC maintains these tools, so bring questions to our dev@ list.
+The ComDev PMC maintains these tools, so bring questions to our [dev@](https://lists.apache.org/list.html?dev@community.apache.org) list.
 
 ### Physical artifacts
 
-* Stickers: Files for you to print, as well as shipping
-  stickers to some events, depending on geography
-* Brochures: Files for you to print, for the ASF as a
-  whole, and for various projects
-* Banners and other promotional objects
-* Assistance with producing swag
-
-### Book/Documentation Sprints
-
-* Coordinating and producing documentation or book sprints
+* Stickers: Request project stickers for your event, depending on geography
+* Assistance with producing [swag for your project](https://www.redbubble.com/people/comdev/shop)
 
 ## About This Website
 


### PR DESCRIPTION
Remove some items from the "what we do" page that we don't actually do. See https://cwiki.apache.org/confluence/display/COMDEV/Website for further discussion.