### PR TITLE
The speakers tool, at community.zones.apache.org, has been abandoned for

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -147,9 +147,7 @@
                 <a class="dropdown-item" href="https://www.apache.org/foundation/marks/events">Apache event branding policies</a>
                 <div class="dropdown-divider"></div>
                 <a class="dropdown-item text-uppercase disabled" href="#">Speakers</a>
-                <a class="dropdown-item" href="/speakers/">Speaker Information</a>
-                <a class="dropdown-item" href="/speakers/speakers.html">Finding Speakers / Listing Yourself as a Speaker</a>
-                <a class="dropdown-item" href="/speakers/slides.html">Apache-related Slides</a>
+                <a class="dropdown-item" href="/speakers/slides.html">Sample presentations</a>
               </div>
             </li>
             <li class="nav-item dropdown">

--- a/source/_index.md
+++ b/source/_index.md
@@ -33,10 +33,9 @@ in the specific Apache projects that interest you.
         <p>The ASF is a large organization made up of many separate projects: each project community may have its own ways of working, while still following the basic Apache Way process.</p>
     </div>
     <div class="col-md-4">
-        <h4>Event Organizers and Speakers</h4>
-        <p>We have a <a href="speakers/index.html">list of speaker resources</a> for conference organizers and speakers, including some useful Apache slides.</p>
+        <h4>Events</h4>
         <p>Producers should read our <a href="https://www.apache.org/foundation/marks/events">Event Branding Policy</a> for ticketed events, and we have some <a href="events/small-events.html">tips for organizing small community events</a> about Apache projects.</p>
-        <p>The <a href="https://events.apache.org/event/calendar.html">master event calendar</a> contains an aggregation of many different Apache-related events, including ApacheCon and BarCamps.</p>
+        <p>The <a href="https://events.apache.org/event/calendar.html">event calendar</a> lists approved Apache-related events, including Community Over Code (formerly ApacheCon) and project summits.</p>
     </div>
     <div class="col-md-4">
         <h4>The Foundation</h4>

--- a/source/about/__index.md
+++ b/source/about/__index.md
@@ -25,8 +25,7 @@ provides a wide array of information, [FAQs](/newbiefaq.html), and help to newco
 - Partnered Industry Events (FOSDEM etc.)
 - MeetUps, Apache BarCamps, etc.
 - Event Representatives (booth coverage, etc.)
-- [Speaker Resources](/speakers/)
-- [Stock Presentations](/speakers/slides.html)
+- [Sample Presentations](/speakers/slides.html)
 
 ### Diversity
 - [Code of Conduct](https://www.apache.org/foundation/policies/conduct.html)

--- a/source/committers/__index.md
+++ b/source/committers/__index.md
@@ -85,14 +85,6 @@ activities, although non-committers can often act in supporting roles.
 
 We encourage all of our committers to speak about Apache projects and 
 technologies, and generally to help to grow and enhance our community.
-For more information, see our 
-[Speakers section](/speakers/).
-
-In addition, we encourage all committers to list themselves as
-"Local Mentors", and thus help new committers
-and would-be committers. For more information on what this program involves,
-and how to sign yourself up for it, see the 
-[Local Mentors](/localmentors.html) page.
 
 ## Other Resources
 

--- a/source/newbiefaq.md
+++ b/source/newbiefaq.md
@@ -20,7 +20,6 @@ The Apache Software Foundation (ASF) and our many Apache projects understand how
   - [About the Apache Mentoring Programme](#NewbieFAQ-AbouttheApacheMentoringProgramme)
       - [What is the Apache Mentoring Programme?](#NewbieFAQ-WhatistheApacheMentoringProgramme)
       - [How do I apply to the Mentor Programme?](#NewbieFAQ-HowdoIApplytotheMentorProgramme?)
-  - [Finding Apache speakers for events or meetups](#NewbieFAQ-AboutSpeakers)
   - [How do I suggest or make changes to this website?](#websitecms)
   - [What other useful websites about Apache are there?](#comdevweb) 
   - [How do I report a bug for Comdev websites or tools?](#comdevbug)   
@@ -210,14 +209,6 @@ need to complete an [application](mentorprogrammeapplication.html). This
 gives us enough background information to enable us to approach your
 chosen project community and for you to work with prospective mentors in
 defining your mentored activity.
-
-<a name="NewbieFAQ-AboutSpeakers"></a>
-## How can I find speakers willing to help us understand Apache?
-
-The best way to start getting involved is to join the 
-[dev@community.apache.org](##NewbieFAQ-HowdoIaskaquestionabouttheASFingeneral?)
-mailing list. We also have a [listing of volunteer speakers](/speakers/) 
-who might be willing to share slides or talks about the ASF.
 
 # How do I suggest changes to this website? # {#websitecms}
 

--- a/source/speakers/slides.md
+++ b/source/speakers/slides.md
@@ -8,8 +8,7 @@ been presented at [ApacheCon conferences](https://events.apache.org) or
 other open source conferences.
 
 These presentations are available under permissive licenses; please see
-each individual presentation for license details.  More tips and links for
-[speakers](/speakers/index.html) are available.
+each individual presentation for license details.
 
 Many Apache speakers post their slides to the [SlideShare website](//www.slideshare.net/search/slideshow?searchfrom=header&q=apache+software),
 and the [FeatherCast podcast offers audio recordings](//feathercast.apache.org/) of many talks and interviews.


### PR DESCRIPTION
The speakers tool, at community.zones.apache.org, has been abandoned for a very long time, and we really shouldn't be promoting it.

This removes links, but leaves the speakers/ directory, which has some (possibly?) useful links in it. I'll come back and clean that up some more when I have some time.
