### PR TITLE
Fix broken links by adding the old URLs as alias

### DIFF
--- a/source/gsoc/_index.md
+++ b/source/gsoc/_index.md
@@ -1,6 +1,8 @@
 ---
 title: GSoC
 url: /gsoc/
+aliases:
+- /gsoc.html
 ---
 
 <div class="card mb-3">

--- a/source/gsoc/experiences.md
+++ b/source/gsoc/experiences.md
@@ -1,5 +1,7 @@
 ---
 title: Apache in GSoC
+aliases:
+- /mentoring/experiences.html
 ---
 
 *This should be in the GSoC directory*

--- a/source/gsoc/gsoc-admin-tasks.md
+++ b/source/gsoc/gsoc-admin-tasks.md
@@ -1,5 +1,7 @@
 ---
-title: GSoC admins 
+title: GSoC admins
+aliases:
+- /gsoc-admin-tasks.html
 ---
 
 A comprehensive guide to being a GSoC admin for the ASF

--- a/source/gsoc/guide-to-being-a-mentor.md
+++ b/source/gsoc/guide-to-being-a-mentor.md
@@ -1,5 +1,7 @@
 ---
-title: guide to being a mentor
+title: Guide to being a mentor
+aliases:
+- /guide-to-being-a-mentor.html
 ---
 
 <!--

--- a/source/gsoc/mentee-ranking-process.md
+++ b/source/gsoc/mentee-ranking-process.md
@@ -1,5 +1,7 @@
 ---
 title: Mentee Ranking Process
+aliases:
+- /mentee-ranking-process.html
 ---
 
 This page describes the ranking process The Apache Software

--- a/source/gsoc/use-the-comdev-gsoc-issue-tracker-for-gsoc-tasks.md
+++ b/source/gsoc/use-the-comdev-gsoc-issue-tracker-for-gsoc-tasks.md
@@ -1,5 +1,7 @@
 ---
 title: Use the Comdev Issue Tracker For GSoC Tasks
+aliases:
+- /use-the-comdev-issue-tracker-for-gsoc-tasks.html
 ---
 
 If your project does not use the ASF Jira for issue tracking, you can use


### PR DESCRIPTION
This makes use of Hugo aliases for referring to old URLs:
https://gohugo.io/content-management/urls/#aliases

If it is easier to do this in the `.htaccess` file, feel free to close this PR.

Otherwise, feel free to merge.

I tested this locally.

/cc @sebbASF 