### PR TITLE
Add tag-based navigation

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -11,8 +11,11 @@ enableRobotsTXT = true
 disableBrowserError = true
 timeout = 3000
 
-disableKinds = ["taxonomy", "taxonomyTerm"]
 ignoreFiles = [ ] # No files to ignore
+
+# Enable tags but not categories
+[taxonomies]
+tag = "tags"
 
 # Highlighting config. See https://help.farbox.com/pygments.html
 pygmentsCodeFences = true

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -158,6 +158,7 @@
       </section>
       {{ partial "breadcrumbs.html" . }}
       <hr>
+      {{ partial "tags.html" .}}
       {{ block "main" . }}{{ end }}
     </div>
   </main>

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,0 +1,11 @@
+{{ define "main" }}
+<h2>Pages having the <em>{{ .Title }}</em> tag</h2>
+<p>See also the <a href="/tags.html">list of tags</a>.</p>
+<ul>
+    {{ range .Data.Pages }}
+    <li>
+      <a href="{{.RelPermalink}}">{{ .Title }}</a>
+    </li>
+    {{ end }}
+  </ul>
+{{ end }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+<h2>All tags</h2>
+<ul>
+    {{ range .Pages }}
+        <li>
+            <a href="{{ .Permalink }}">{{ .Title }}</a>
+        </li>
+    {{ end }}
+</ul>
+{{ end }}

--- a/layouts/partials/tags.html
+++ b/layouts/partials/tags.html
@@ -1,0 +1,11 @@
+{{ $taxonomy := "tags" }} {{ with .Param $taxonomy }}
+<ul class="tags-list">
+  {{ range $index, $tag := . }}
+  {{ with $.Site.GetPage (printf "/%s/%s" $taxonomy $tag) -}}
+  <li>
+    <a href="{{ .Permalink }}">{{ $tag | urlize }}</a>
+  </li>
+  {{- end -}}
+  {{- end -}}
+</ul>
+{{ end }}

--- a/source/about/_index.md
+++ b/source/about/_index.md
@@ -1,6 +1,7 @@
 ---
 title: "Community Development: What we do"
 url: /about/
+tags: ["faq","navigation"]
 ---
 
 ## Community Development: What We Do

--- a/source/apache-way/apache-project-maturity-model.md
+++ b/source/apache-way/apache-project-maturity-model.md
@@ -1,5 +1,6 @@
 ---
 title: A Maturity Model for Apache Projects
+tags: ["governance","maturity","incubator"]
 ---
 
 The **Apache Project Maturity Model** provides a suggested framework for evaluating the overall maturity of an Apache project community and the codebase that it maintains.  While this model is specific to projects of the Apache Software Foundation (ASF), many of these factors apply to any open source project.

--- a/source/blog/2023-preparing-the-move.md
+++ b/source/blog/2023-preparing-the-move.md
@@ -4,6 +4,7 @@ url: /blog/preparing-the-move/
 description: We're about to move our blog here
 date: 2023-04-20
 blog_post: true
+tags: ["blog"]
 ---
 
 We're in the process of moving our content here from the 

--- a/source/blog/_index.md
+++ b/source/blog/_index.md
@@ -2,6 +2,7 @@
 title: Community Development Blog
 url: /blog/
 list_pages: true
+tags: ["blog"]
 ---
 
 ## Community Development Blog

--- a/source/boardreport.md
+++ b/source/boardreport.md
@@ -1,5 +1,6 @@
 ---
 title: BoardReport
+tags: ["reporting"]
 ---
 
 For complete details about what should be in ASF project board reports, including instructions on using the handy Reporter tool, please see:

--- a/source/calendars/_index.md
+++ b/source/calendars/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Apache Related Event Calendars
 url: /calendars/
+tags: ["calendars","events","conferences"]
 ---
 
 This calendar lists major events relating to The Apache Software Foundation

--- a/source/calendars/conferences.md
+++ b/source/calendars/conferences.md
@@ -1,5 +1,6 @@
 ---
 title: Apache Conferences Calendar
+tags: ["calendars","events","conferences"]
 ---
 
 ## Deprecated - See New Calendar instead

--- a/source/comdevboardreports.md
+++ b/source/comdevboardreports.md
@@ -1,5 +1,6 @@
 ---
 title: ComDevBoardReports
+tags: ["pmc","board"]
 ---
 
 Like every other ASF project, the ComDev PMC sends a [quarterly report to the board](https://www.apache.org/foundation/board/reporting).  These reports are read by the board, and sometimes directors will ask the PMC for clarification or to make suggestions for the project.

--- a/source/committers/voting.md
+++ b/source/committers/voting.md
@@ -1,5 +1,6 @@
 ---
 title: Voting
+tags: ["pmc","governance","voting"]
 ---
 
 Occasionally a "feel" for consensus is not enough. Sometimes we need to 

--- a/source/contributor-ladder.md
+++ b/source/contributor-ladder.md
@@ -1,5 +1,6 @@
 ---
 title: ASF Contributor Ladder
+tags: ["pmc","roles","committers","members","officers","board"]
 ---
 
 Projects at the ASF offer a way to grow in your responsibilities in the

--- a/source/contributors/_index.md
+++ b/source/contributors/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Contributing to the Apache Software Foundation
 url: /contributors/
+tags: ["faq","navigation","contributing"]
 ---
 
 This page is for people who are reasonably 

--- a/source/contributors/becomingacommitter.md
+++ b/source/contributors/becomingacommitter.md
@@ -1,6 +1,7 @@
 ---
 title: Becoming a committer
 slug: becomingacommitter
+tags: ["committers","newcomers","contributing"]
 ---
 
 {{% toc %}}

--- a/source/contributors/etiquette.md
+++ b/source/contributors/etiquette.md
@@ -1,5 +1,6 @@
 ---
 title: ASF Community Etiquette Guidelines
+tags: ["etiquette","conduct"]
 ---
 
 The ASF and our many projects welcome all 

--- a/source/contributors/mailing-lists.md
+++ b/source/contributors/mailing-lists.md
@@ -1,5 +1,6 @@
 ---
 title: Mailing lists
+tags: ["communication","mailing-lists"]
 ---
 
 The ASF has a long tradition of using mailing lists as the primary

--- a/source/events/small-events.md
+++ b/source/events/small-events.md
@@ -1,5 +1,6 @@
 ---
 title: Requirements for organizers of small Apache-related events
+tags: ["events"]
 ---
 
 # Approval of small Apache-related events

--- a/source/gettingStarted/101.md
+++ b/source/gettingStarted/101.md
@@ -1,5 +1,6 @@
 ---
 title: Getting started
+tags: ["newcomers"]
 ---
 
 # Where do I start?

--- a/source/gsoc/gsoc-admin-tasks.md
+++ b/source/gsoc/gsoc-admin-tasks.md
@@ -1,5 +1,6 @@
 ---
-title: GSoC admins 
+title: GSoC admins
+tags: ["gsoc","mentoring"]
 ---
 
 A comprehensive guide to being a GSoC admin for the ASF

--- a/source/history/boardresolution.md
+++ b/source/history/boardresolution.md
@@ -1,5 +1,6 @@
 ---
 title: ComDevBoardResolution
+tags: ["history"]
 ---
 The Apache Community Development Project was created in November 2009.
 

--- a/source/history/mentoringprogramme-icfoss-pilot.md
+++ b/source/history/mentoringprogramme-icfoss-pilot.md
@@ -1,5 +1,6 @@
 ---
 title: Pilot Mentoring Programme with India ICFOSS
+tags: ["history","mentoring","india"]
 ---
 
 > Note that this information is about a pilot program that

--- a/source/mentoring/_index.md
+++ b/source/mentoring/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Mentoring
 url: /mentoring/
+tags: ["mentoring"]
 ---
 
 # Mentoring

--- a/source/mentoring/committer.md
+++ b/source/mentoring/committer.md
@@ -1,5 +1,6 @@
 ---
 title: Mentoring a new committer
+tags: ["mentoring","committers"]
 ---
 
 # Mentoring a new committer

--- a/source/mentoring/firstpatch.md
+++ b/source/mentoring/firstpatch.md
@@ -1,5 +1,6 @@
 ---
 title: "Mentoring: First Patch"
+tags: ["mentoring","newcomers","patch"]
 ---
 
 # Mentoring: First Patch

--- a/source/mentoring/mentor.md
+++ b/source/mentoring/mentor.md
@@ -1,5 +1,6 @@
 ---
 title: Mentoring Mentors
+tags: ["mentoring"]
 ---
 
 # Mentoring Mentors

--- a/source/mentoring/pmc.md
+++ b/source/mentoring/pmc.md
@@ -1,5 +1,6 @@
 ---
 title: Mentoring a new PMC member
+tags: ["mentoring","pmc"]
 ---
 
 # Mentoring a new PMC member

--- a/source/newbiefaq.md
+++ b/source/newbiefaq.md
@@ -1,5 +1,6 @@
 ---
 title: Apache Newcomer FAQs
+tags: ["newcomers","faq"]
 ---
 
 These answers to frequently asked questions may help newcomers to

--- a/source/newcomers/_index.md
+++ b/source/newcomers/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Welcome, Apache newcomers!
 url: /newcomers/
+tags: ["newcomers"]
 ---
 
 In this section we'll help you take your first steps as an open source 
@@ -9,7 +10,7 @@ run organization, Apache and the many Apache projects rely on people like
 you stepping up to help out.  
 
   * [Where do I start?](/gettingStarted/101.html) - a guide to your first engagement with an Apache project
-  * [How should I behave?](/contributors/etiquette) - etiquette and codes of conduct at Apache
+  * [How should I behave?](/contributors/etiquette.html) - etiquette and codes of conduct at Apache
   * [Newbie FAQ](/newbiefaq.html) - some commonly asked questions (and their answers)
   * [How many projects are at Apache?](https://projects.apache.org/) - we have a **LOT** of different project communities!
   * [Just show me the code!](https://www.apache.org/dev/) - site index of technical questions (where's SVN, how to log in, etc.)

--- a/source/newcommitter.md
+++ b/source/newcommitter.md
@@ -1,5 +1,6 @@
 ---
 title: New Committer
+tags: ["pmc","committers","election"]
 ---
 
 Identifying potential new committers, calling a vote for their recognition

--- a/source/newsletter/2017-04.md
+++ b/source/newsletter/2017-04.md
@@ -1,5 +1,6 @@
 ---
 title: April 2017 Community Newsletter
+tags: ["newsletter"]
 ---
 
 # Apache Committer Newsletter, April 2017

--- a/source/newsletter/2017-05.md
+++ b/source/newsletter/2017-05.md
@@ -1,5 +1,6 @@
 ---
 title: May 2017 Community Newsletter
+tags: ["newsletter"]
 ---
 
 

--- a/source/newsletter/_index.md
+++ b/source/newsletter/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Newsletter
 url: /newsletter/
+tags: ["newsletter"]
 ---
 
 # Community Development Newsletter

--- a/source/pmc/_index.md
+++ b/source/pmc/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Project Management Committees
 url: /pmc/
+tags: ["pmc"]
 ---
 
 The Project Management Committee, or PMC, is the technical steering

--- a/source/pmc/adding-committers.md
+++ b/source/pmc/adding-committers.md
@@ -1,5 +1,6 @@
 ---
 title: Adding Committers
+tags: ["pmc","committers"]
 ---
 
 The addition of new committers is essential to the long-term 

--- a/source/pmc/adding-pmc-members.md
+++ b/source/pmc/adding-pmc-members.md
@@ -1,5 +1,6 @@
 ---
 title: Adding PMC members
+tags: ["pmc","election"]
 ---
 
 The PMC is responsible for identifying individuals who should be added

--- a/source/pmc/chair.md
+++ b/source/pmc/chair.md
@@ -1,5 +1,6 @@
 ---
 title: PMC Chair
+tags: ["pmc","chair"]
 ---
 
 The PMC Chair acts as the voice of the project to the board, and is

--- a/source/pmc/new-member.md
+++ b/source/pmc/new-member.md
@@ -1,5 +1,6 @@
 ---
 title: New PMC Members
+tags: ["pmc","election"]
 ---
 
 You've been invited to join a project PMC? Congratulations! What should

--- a/source/pmc/reporting.md
+++ b/source/pmc/reporting.md
@@ -1,5 +1,6 @@
 ---
 title: PMC Reporting
+tags: ["pmc","reporting"]
 ---
 
 A PMC is required to file a report to the Board of Directors every

--- a/source/pmc/responsibilities.md
+++ b/source/pmc/responsibilities.md
@@ -1,5 +1,6 @@
 ---
 title: PMC Responsibilities
+tags: ["pmc","governance"]
 ---
 
 The Project Management Committee (PMC) is responsible for the oversight

--- a/source/projectIndependence.md
+++ b/source/projectIndependence.md
@@ -1,5 +1,6 @@
 ---
 title: Project Independence
+tags: ["pmc","governance"]
 ---
 
 While not all ASF projects practice all aspects of the Apache Way in the same way, there are a number of rules and policies that Apache 

--- a/source/proposals/ZestProposal.md
+++ b/source/proposals/ZestProposal.md
@@ -1,4 +1,7 @@
+---
 title: Zest Proposal
+tags: ["proposals","zest","history"]
+---
 
 # Abstract
 

--- a/source/speakers/_index.md
+++ b/source/speakers/_index.md
@@ -1,6 +1,7 @@
 ---
 title: Speaking about Apache, our Projects and our Community
 url: /speakers/
+tags: ["speakers","conferences"]
 ---
 
 If you are looking for speakers for an event, or are a speaker looking for 

--- a/source/speakers/slides.md
+++ b/source/speakers/slides.md
@@ -1,5 +1,6 @@
 ---
 title: Apache-related slides, videos and presentations
+tags: ["speakers","conferences","slides","video"]
 ---
 
 This page contains links to presentations and other key papers about the ASF and how

--- a/source/speakers/speakers.md
+++ b/source/speakers/speakers.md
@@ -1,5 +1,6 @@
 ---
 title: Listing yourself as a Potential Speaker
+tags: ["speakers","conferences"]
 ---
 
 If you're an Apache committer interested in speaking about Apache 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -44,3 +44,19 @@ dt:hover > .headerlink, p:hover > .headerlink, td:hover > .headerlink, h1:hover 
   font-size: 80%;
   font-style: italic;
 }
+
+ul.tags-list {
+  padding-left: 0;
+  font-size: 90%;
+  display:flex;
+  list-style-type: none;
+  flex-wrap:wrap;
+}
+
+.tags-list li {
+  margin-right:.5rem;
+  margin-top: 0.25rem;
+  padding-left: 0.25rem;
+  padding-right: 0.25rem;
+  background-color: var(--light);
+}


### PR DESCRIPTION
Tag navigation in the preview at https://community-tags.staged.apache.org/ doesn't work as Hugo generates absolute URLs, I don't know how to change that.

Anyway the risk of this breaking anything is very low so I'll merge this PR so people can test it at https://community.apache.org/ - we can always revert if needed.