### PR TITLE
Add a failure and fixed section to the Jenkinsfile for sending notifications

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -168,5 +168,43 @@ pipeline {
             }
             deleteDir() /* clean up our workspace */
         }
+
+        // If the build failed, send an email to the list.
+        failure {
+            script {
+                if (env.BRANCH_NAME == 'main') {
+                    emailext(
+                        to: "dev@community.apache.org",
+                        recipientProviders: [[$class: 'DevelopersRecipientProvider']],
+                        from: "Jenkins <jenkins@ci-builds.apache.org>",
+                        subject: "Jenkins job ${env.JOB_NAME}#${env.BUILD_NUMBER} failed",
+                        body: """
+There is a build failure in ${env.JOB_NAME}.
+
+Build: ${env.BUILD_URL}
+"""
+                    )
+                }
+            }
+        }
+
+        // Send an email, if the last build was not successful and this one is.
+        fixed {
+            script {
+                if (env.BRANCH_NAME == 'main') {
+                    emailext(
+                        to: "dev@community.apache.org",
+                        recipientProviders: [[$class: 'DevelopersRecipientProvider']],
+                        from: 'Jenkins <jenkins@ci-builds.apache.org>',
+                        subject: "Jenkins job ${env.JOB_NAME}#${env.BUILD_NUMBER} back to normal",
+                        body: """
+The build for ${env.JOB_NAME} completed successfully and is back to normal.
+
+Build: ${env.BUILD_URL}
+"""
+                    )
+                }
+            }
+        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,7 +177,7 @@ pipeline {
                         to: "dev@community.apache.org",
                         recipientProviders: [[$class: 'DevelopersRecipientProvider']],
                         from: "Jenkins <jenkins@ci-builds.apache.org>",
-                        subject: "Jenkins job ${env.JOB_NAME}#${env.BUILD_NUMBER} failed",
+                        subject: "[website] Jenkins job ${env.JOB_NAME}#${env.BUILD_NUMBER} failed",
                         body: """
 There is a build failure in ${env.JOB_NAME}.
 
@@ -196,7 +196,7 @@ Build: ${env.BUILD_URL}
                         to: "dev@community.apache.org",
                         recipientProviders: [[$class: 'DevelopersRecipientProvider']],
                         from: 'Jenkins <jenkins@ci-builds.apache.org>',
-                        subject: "Jenkins job ${env.JOB_NAME}#${env.BUILD_NUMBER} back to normal",
+                        subject: "[website] Jenkins job ${env.JOB_NAME}#${env.BUILD_NUMBER} back to normal",
                         body: """
 The build for ${env.JOB_NAME} completed successfully and is back to normal.
 


### PR DESCRIPTION
I think it is useful to ping the dev@ list if a deployment of our main branch failed. Build failures might go unnoticed otherwise.

I couldn't use the `when { branch 'main' }` since that apparently doesn't work in the `post` section: https://stackoverflow.com/a/49812779