### PR TITLE
Make github email subjects more readable

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -7,6 +7,26 @@ github:
     - comdev
     - hugo
 
+# Attempt to make the auto-generated github emails more easily readable in email clients.
+custom_subjects:
+  new_pr: "[PR] {title} ({repository})"
+  close_pr: "Re: [PR] {title} ({repository})"
+  comment_pr: "Re: [PR] {title} ({repository})"
+  diffcomment: "Re: [PR] {title} ({repository})"
+  merge_pr: "Re: [PR] {title} ({repository})"
+  new_issue: "[I] {title} ({repository})"
+  comment_issue: "Re: [I] {title} ({repository})"
+  close_issue: "Re: [I] {title} ({repository})"
+  catchall: "[GH] {title} ({repository})"
+  new_discussion: "[D] {title} ({repository})"
+  edit_discussion: "Re: [D] {title} ({repository})"
+  close_discussion: "Re: [D] {title} ({repository})"
+  close_discussion_with_comment: "Re: [D] {title} ({repository})"
+  reopen_discussion: "Re: [D] {title} ({repository})"
+  new_comment_discussion: "Re: [D] {title} ({repository})"
+  edit_comment_discussion: "Re: [D] {title} ({repository})"
+  delete_comment_discussion: "Re: [D] {title} ({repository})"
+
 notifications:
   commits:      commits@community.apache.org
   issues:       dev@community.apache.org
@@ -22,3 +42,4 @@ staging:
   profile: ~
   whoami:  asf-staging
   autostage: preview/*
+


### PR DESCRIPTION
Shamelessly stolen from the PLC4x repo, where it was crafted by @chrisdutz 
This makes auto-generated email from GitHub more readable, especially on narrow (ie, phone) email clients, by consolidating all of the auto-generated stuff and getting right to the subject. This also results in the resulting discussion (ie, comments and eventual close on PRs, for example) being grouped into a single thread, rather than split over several threads. See the dev@logging and PLC4x lists for a demonstration.