### PR TITLE
events.apache.org is canonical

### DIFF
--- a/source/calendars/_index.md
+++ b/source/calendars/_index.md
@@ -42,18 +42,6 @@ This Calendar is also available as an [iCal feed][3]
 <script src="https://events.apache.org/js/events-calendar.js"></script>
 <script src="https://apis.google.com/js/client.js"></script>
 
-## Other Related Events
-
-In addition to major conferences that have applied for approval with us, there are a wide range of other
-events which feature Apache projects and technologies. A list of upcoming
-[Apache related Meetups is available][5], powered in part by [this script][6]
-(patches welcome!). Secondly, a crowd-sourced list of related events is maintained
-as a [Lanyrd Guide][4], and we encourage people to help list
-Apache project related events there.
-
   [1]: mailto:dev@community.apache.org
   [2]: https://www.apache.org/foundation/marks/events.html
   [3]: https://www.google.com/calendar/ical/nerseigospses068jd57bk5ar8%40group.calendar.google.com/public/basic.ics
-  [4]: http://lanyrd.com/guides/apache-software-and-technologies/
-  [5]: https://events.apache.org/event/index.html
-  [6]: https://svn.apache.org/repos/asf/comdev/tools/get_meetups

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -9,4 +9,6 @@ Redirect /mentoring/experiences.html /gsoc/experiences.html
 
 RedirectMatch ^/tags/$ /tags.html
 
-Redirect /calendars/conferences.html /calendars/
+Redirect /calendars/conferences.html https://events.apache.org/
+Redirect /calendars/ https://events.apache.org/
+


### PR DESCRIPTION
Move calendar reference to https://events.apache.org/ which is the canonical source of ASF events. Also removes references to long-defunct resources, in case someone gets to the old resource somehow.

Presumably eventually we just drop the entire calendars/ directory, right?
