### PR TITLE
Activate RSS feeds

### DIFF
--- a/hugo.toml
+++ b/hugo.toml
@@ -1,5 +1,5 @@
 baseURL = "https://community.apache.org"
-title = "Apache Comdev"
+title = "ASF Community Development"
 languageCode = "en"
 
 contentDir = "source"
@@ -48,3 +48,8 @@ tags = ["OpenSource", "Community", "Apache Software Foundation"]
 
 [social]
 twitter = "ApacheCommunity"
+
+[outputs]
+home = ["html","rss"]
+term = ["html"]
+section = ["html","rss"]

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -43,6 +43,7 @@
   </style>
 
   {{ partial "matomo.html" . }}
+  {{ partial "rssfeed.html" . }}
 </head>
 
 <body>

--- a/layouts/partials/rssfeed.html
+++ b/layouts/partials/rssfeed.html
@@ -1,0 +1,3 @@
+{{ with .OutputFormats.Get "rss" -}}
+  {{ printf `<link rel=%q type=%q href=%q title=%q>` .Rel .MediaType.Type .Permalink site.Title | safeHTML }}
+{{ end }}

--- a/source/_index.md
+++ b/source/_index.md
@@ -29,6 +29,8 @@ and best practices apply to other projects as well.
 
 If you're new to the ASF, and are looking for where to get involved, [you can find relevant information here](/tags/newcomers.html).
 
+RSS feeds allow you to subscribe to our content, section pages such as the [blog](/blog/) and [pmc](/pmc/) pages each have their own
+feed.
 </div>
 
 <a name="Index-Startingpoints"></a>

--- a/source/blog/rss-feeds-activated.md
+++ b/source/blog/rss-feeds-activated.md
@@ -1,0 +1,10 @@
+---
+title: RSS feeds activated
+date: 2023-10-24
+blog_post: true
+---
+
+We have activated RSS feeds on this website.
+
+Section pages such as the [blog](/blog/) and [pmc](/pmc/) pages each have their own
+feed, to which you can subscribe to stay updated.


### PR DESCRIPTION
RSS feeds were already generated by Hugo but were not linked from the pages.

This PR adds RSS feed links to section pages (`/blog`, `/pmc`, etc.), with a feed per section, and disables the feeds for the tags pages ("terms" page type).

We might create a `/news` section, distinct from the blog, for short news that people can subscribe to.