### PR TITLE
Slight rearrangement of nav bar

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -55,6 +55,17 @@
           </div>
         </li>
         <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="commitDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            For Committers/PMCs
+          </a>
+          <div class="dropdown-menu" aria-labelledby="commitDropdown">
+            <a class="dropdown-item" href="/newcommitter.html">Recruiting New Committers</a>
+            <a class="dropdown-item" href="/committers/">Useful Information for Committers</a>
+            <a class="dropdown-item" href="/committers/decisionMaking.html">Decision Making</a>
+            <a class="dropdown-item" href="/committers/funding-disclaimer.html">Funding Campaign Disclaimer</a>
+          </div>
+        </li>
+        <li class="nav-item dropdown">
           <a class="nav-link dropdown-toggle" href="#" id="commitDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">GSoC</a>
           <div class="dropdown-menu" aria-labelledby="gsocDropdown">
             <a class="dropdown-item" href="/gsoc/">Google Summer Of Code Information</a>
@@ -64,17 +75,6 @@
             <a class="dropdown-item" href="/gsoc/use-the-comdev-gsoc-issue-tracker-for-gsoc-tasks.html">Using ComDev's Jira for GSoC Ideas</a>
             <a class="dropdown-item" href="/gsoc/gsoc-admin-tasks.html">Tasks of a GSoC Admin at the ASF</a>
             <a class="dropdown-item" href="https://issues.apache.org/jira/projects/GSOC">GSoC Jira</a>
-          </div>
-        </li>
-        <li class="nav-item dropdown">
-          <a class="nav-link dropdown-toggle" href="#" id="commitDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-            For Committers/PMCs
-          </a>
-          <div class="dropdown-menu" aria-labelledby="commitDropdown">
-            <a class="dropdown-item" href="/newcommitter.html">Recruiting New Committers</a>
-            <a class="dropdown-item" href="/committers/">Useful Information for Committers</a>
-            <a class="dropdown-item" href="/committers/decisionMaking.html">Decision Making</a>
-            <a class="dropdown-item" href="/committers/funding-disclaimer.html">Funding Campaign Disclaimer</a>
           </div>
         </li>
         <li class="nav-item dropdown">


### PR DESCRIPTION
Moves "for contributors" and "for committers/pmcs" next to each other. Having GSoC between them has always seemed a bit out of logical order.
