### PR TITLE
Remove reference to defunct RSS feeds

### DIFF
--- a/source/_index.md
+++ b/source/_index.md
@@ -28,9 +28,6 @@ We are primarily focused on ASF projects, but we believe that our
 and best practices apply to other projects as well.
 
 If you're new to the ASF, and are looking for where to get involved, [you can find relevant information here](/tags/newcomers.html).
-
-RSS feeds allow you to subscribe to our content, section pages such as the [blog](/blog/) and [pmc](/pmc/) pages each have their own
-feed.
 </div>
 
 <a name="Index-Startingpoints"></a>


### PR DESCRIPTION
Reopens https://github.com/apache/comdev-site/pull/150 which git auto-closed when I was trying to fix my git clone. Have I mentioned I hate git?