### PR TITLE
doc: remove usage of CoPDoC

### DIFF
--- a/source/contributors/_index.md
+++ b/source/contributors/_index.md
@@ -63,13 +63,13 @@ See also this [detailed advice for how to become a committer](/contributors/beco
 ## Anyone Can Become A Committer
 
 There is nothing at the Apache Software Foundation that says you must write code 
-in order to be a committer. Anyone who is supportive of the community and works 
-in any of the CoPDoC areas is a likely candidate for committership.
+in order to be a committer. Anyone who is supportive by contributing towards project,
+community, documentation or code is a likely candidate for committership.
 
-Apache strives to be meritocratic. That is, once someone has contributed sufficiently to 
-any area of CoPDoC they can be voted in as a committer. Being a committer does 
-not necessarily mean you commit code; it means you are committed to the project
-and are productively contributing to its success.
+Apache strives to be meritocratic. That is, once someone has contributed sufficiently 
+towards the project, they can be voted in as a committer. Being a committer does not 
+necessarily mean you commit code; it means you are committed to the project and are 
+productively contributing to its success.
 
 One of the key contributions people can make to the community is through the 
 support of a wide user base by assisting users on the user list, writing user-oriented docs and ensuring the developers understand the user viewpoint. 


### PR DESCRIPTION
Took me a while to figure out what "CoPDoC" stood for.

I had to search for this acronym and found its meaning from other Apache projects, such as:

- https://streampark.apache.org/community/contribution_guide/become_committer/
- https://github.com/apache/ignite-3/blob/main/CONTRIBUTING.md#needed-contributions
- https://www.mail-archive.com/dev@servicecomb.apache.org/msg04675.html
- https://kyuubi.apache.org/become_pmc_member.html

I was going to submit a PR to add the meaning of the acronym to this page, but then I noticed the last commit on this file actually removed it, about 10 months ago.

- https://github.com/apache/comdev-site/pull/118

If we are removing the acronym's definition, I think we should also remove its usage.

In my opinion, I didn't see anything wrong with the acronym, but perhaps the "Contributing A Project - CoPDoC" section could have been merged with the "Anyone Can Become A Committer" section at the point it's first used.

It seems the acronym was added by SorraTheOrc in 2011 and mentioned a few times in the mailing list, but I couldn't find a discussion thread about its creation.

The primary reason I encountered this acronym is because I am seeking to enhance the contributing documentation for the project I am involved with. I aimed to clearly communicate that anyone could contribute to various aspects of the project, including Project (CI, team communication, task flow, etc.), Community (supporting users in how to use the project or responding to tickets), Documentation, and Code. Not limited to code only.