### PR TITLE
Adds practical community building advice.

### DIFF
--- a/source/pmc/_index.md
+++ b/source/pmc/_index.md
@@ -17,6 +17,7 @@ policies](https://www.apache.org/dev/pmc.html#policy).
 * [Voting](#voting)
 * [Reporting](#reporting)
 * [Adding committers](#adding-committers)
+* [Encouraging community growth](#community-growth)
 * [Adding PMC members](#adding-pmc-members)
 * [What to do as a new PMC member](#what-to-do-as-a-new-member)
 
@@ -68,6 +69,13 @@ The addition of committers is essential to the long-term
 sustainability of an open source project. The PMC is responsible for
 determining who will be added as a committer. [Read more about how new
 committers are added to a project](/pmc/adding-committers.html).
+
+## Community growth
+
+Growing your project community takes work. But knowing exactly what to
+do to encourage that growth can be difficult. [Read about practical
+steps you can take to attract new
+contributors](/pmc/community-growth.html).
 
 ## Adding PMC members
 

--- a/source/pmc/adding-committers.md
+++ b/source/pmc/adding-committers.md
@@ -11,6 +11,10 @@ Please see the formal policy and process
 [documentation for adding committers](https://www.apache.org/dev/pmc.html#committer-management). 
 This page discusses best practices in how to think about new committers.
 
+In addition to the mechanisms for adding committers, give some thought
+to [practical steps you can take to attract new
+contributors](/pmc/community-growth.html).
+
 ## Who should be a committer?
 
 Each project must decide what is the correct measure for inviting a new

--- a/source/pmc/community-growth.md
+++ b/source/pmc/community-growth.md
@@ -6,7 +6,7 @@ tags: ["pmc","committers","community"]
 Growing your project community takes work. This document makes practical
 suggestions of how to encourage people to get involved in your project.
 
-## Publish a road map
+## Publish a roadmap
 
 Volunteers can work on whatever they want, and so we have a tendency to
 not want to tell them what to work on. However, publishing a roadmap, or
@@ -16,12 +16,20 @@ people an idea of where they might be able to get involved.
 This also gives a clear sense that the project has ambitions, and is
 going somewhere, rather than that it is stagnating.
 
+It can be very challenging to keep a roadmap current. Having a mechanism
+for tagging open issues with `proposal` or `roadmap` and
+automatimatically extracting that into a web page can help with this.
+
 ## Periodically publish the open issue list
 
 Your ticket tracker allows you to periodically summarize the open
 issues. Sending this to the dev@ list reminds people that there are
 things to work on, and gives them permission, and encouragement, to do
 so.
+
+Consider creating [good first
+issues](/committers/good-first-issues.html) as a place for new
+contributors to get started.
 
 ## Clearly document contribution processes
 

--- a/source/pmc/community-growth.md
+++ b/source/pmc/community-growth.md
@@ -1,0 +1,82 @@
+---
+title: Community Growth
+tags: ["pmc","committers","community"]
+---
+
+Growing your project community takes work. This document makes practical
+suggestions of how to encourage people to get involved in your project.
+
+## Publish a road map
+
+Volunteers can work on whatever they want, and so we have a tendency to
+not want to tell them what to work on. However, publishing a roadmap, or
+even a wishlist of features or improvements that are desired, can give
+people an idea of where they might be able to get involved.
+
+This also gives a clear sense that the project has ambitions, and is
+going somewhere, rather than that it is stagnating.
+
+## Periodically publish the open issue list
+
+Your ticket tracker allows you to periodically summarize the open
+issues. Sending this to the dev@ list reminds people that there are
+things to work on, and gives them permission, and encouragement, to do
+so.
+
+## Clearly document contribution processes
+
+Double-check that your "how to contribute / build / test / submit PR"
+documentation is super clear and easy to follow.  Long-time committers
+on a project often forget all the institutional knowledge they just
+"know", so ensuring the "getting started" document actually works
+for newcomers is always worth looking at.
+
+Encourage newcomers to talk about, and document, their pain points
+during their first contributions, and work towards fixing, or at least
+documenting, those things.
+
+## Publish your contributor ladder
+
+A [contributor ladder](/contributor-ladder.html) is a description of
+various levels of access and responsibility a contributor can progress
+through in your project. This is typically the path from contributor, to
+committer, to PMC member.
+
+Explicitly publish your requirements for each step. For example, if you
+require ten non-trivial patches accepted, or perhaps 3 months of
+involvement, document this on your website so that people don't feel
+that it's random, or that they are driving in the dark.
+
+Consider lowering your bar to entry. Remember that while the risk of
+inviting someone "too early" is that they'll break something, that's why
+you have version control - so you can revert those changes. However, the
+risk of inviting someone too late is that they'll give up and go away
+forever.
+
+## Engage with big users
+
+If you are aware of companies that rely on your project, encourage them
+to think about what they would do if the project retired. This often
+leads to those companies realizing the value they get "for free", and
+starting to contribute in some way.
+
+## Be transparent about project risk
+
+If your project is actually at risk of retiring due to lack of community
+engagement, be transparent about this. Tell your dev and user lists
+about the risk, and tell them specifically where you need help. 
+
+While many users are content to simply consume, when they become aware
+that the project is at risk, it often inspires people to think about
+ways they can get involved.
+
+## Come talk to us
+
+You're always welcome to come talk to the Community Development project,
+for advice and resources. We don't always have all of the answers, but
+we can help you think about the problem, and suggest possible solutions.
+
+Engage with one of our [working groups](/workinggroups/) to help
+implement some of the above advise.
+
+


### PR DESCRIPTION
Adds a new document, inspired by conversations with one of our projects in this situation, suggesting practical steps that a project can take to attract new contributors.