### PR TITLE
feat: polish breadcrumb to display page title

### DIFF
--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -1,5 +1,3 @@
-{{ $url := replace .Permalink ( printf "%s" .Site.BaseURL) "" }}
-{{ $.Scratch.Set "path" "/" }}
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
     <li class="breadcrumb-item"><a href="/">Home</a></li>

--- a/layouts/partials/breadcrumbs.html
+++ b/layouts/partials/breadcrumbs.html
@@ -3,13 +3,22 @@
 <nav aria-label="breadcrumb">
   <ol class="breadcrumb">
     <li class="breadcrumb-item"><a href="/">Home</a></li>
-    {{ range $index, $element := split $url "/" }}
-        {{ $.Scratch.Add "path" $element }}
-        {{ if ne $element "" }}
-            <li class="breadcrumb-item"><a href='{{ $.Scratch.Get "path" }}'>{{ humanize . | replaceRE "\\.[hH]tml$" "" }}</a></li>
-            {{ $.Scratch.Add "path" "/" }}
-        {{ end }}
-    {{ end }}
+    {{ template "breadcrumb" dict "currentPage" .Page "id" .Key }}
   </ol>
 </nav>
 
+{{ define "breadcrumb" }}
+  {{ if .currentPage.Parent }}
+    {{ template "breadcrumb" dict "currentPage" .currentPage.Parent }}
+
+    <li class="breadcrumb-item">
+      {{ if eq .id .currentPage.Key }}
+        {{ .currentPage.Title }}
+      {{ else }}
+        {{ with .currentPage }}
+          <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+        {{ end }}
+      {{ end }}
+    </li>
+  {{ end }}
+{{ end }}


### PR DESCRIPTION
Signed-off-by: suyanhanx <suyanhanx@gmail.com>

I noticed that the breadcrumb on our comdev site is generated by capitalizing the first letter of the fragment of the URL.
This may be wrong some of the time, such as GSoC:
![image](https://github.com/apache/comdev-site/assets/24221472/59e48bf0-5fff-498d-a28c-0ad4f8b466e7)

I polished this breadcrumb. 

After:
![image](https://github.com/apache/comdev-site/assets/24221472/6132523c-9bfe-4ca6-b0cd-4c9efd3fcb6d)

Now it looks better.