### PR TITLE
Fix broken "newpmcmember" link

### DIFF
--- a/source/newcommitter.md
+++ b/source/newcommitter.md
@@ -15,7 +15,7 @@ Some of the PMCs automatically make committers PMC members. The templates below
 have conditional `[if]` clauses for that.
 
 If the PMC has separate process for approving PMC members, see
-[new PMC member](https://community.apache.org/newpcmember.html)
+[new PMC member](newpmcmember.html)
 
 {{% toc %}}
 


### PR DESCRIPTION
The #183 split the committer invite into "committer/pmc member" but the link was broken.

Tested with Hugo locally and it seems it works now.