### PR TITLE
Add {{% toc %}} macro wherever useful

### DIFF
--- a/source/contactpoints.md
+++ b/source/contactpoints.md
@@ -8,6 +8,8 @@ If you have a question about anything Apache, the ComDev project is here to help
 To help us help you, try to direct your question to the right mailing list - our 
 volunteer committers do all their work on mailing lists.
 
+{{% toc %}}
+
 # Community Questions
 
 Email questions about community or issues across multiple Apache projects to [dev@community.apache.org](mailto:dev@community.apache.org?subject=New-Contact-Question) - or see our detailed [Mailing List How To](//community.apache.org/lists.html) page.
@@ -27,6 +29,7 @@ Each of Apache's email lists is privately archived: you can mail to them, and
 we'll answer, but you won't be able to read the archives.
 
 <a name="ContactPoints-Trademarks"></a>
+
 ## Trademarks
 
 Issues regarding trademarks, specific project names, or branding of the
@@ -35,6 +38,7 @@ or send email to [trademarks@apache.org](mailto:trademarks@apache.org).
 
 
 <a name="ContactPoints-PublicityandMarketing"></a>
+
 ## Publicity and Marketing
 
 Issues dealing with publicity, marketing, or any inquires from the
@@ -42,6 +46,7 @@ press or analysts: see our [Press Team Page](https://www.apache.org/press/),
  or email to [press@apache.org](mailto:press@apache.org).
 
 <a name="ContactPoints-FundraisingandSponsorship"></a>
+
 ## Fundraising and Sponsorship
 
 Questions about fundraising, sponsorships, donations, or related
@@ -49,6 +54,7 @@ finances: see our [Donations Information](//www.apache.org/foundation/contributi
 or email to [fundraising@apache.org](mailto:fundraising@apache.org).
 
 <a name="ContactPoints-Legal"></a>
+
 ### Legal
 
 Send specific legal questions that may need to be private, and require a
@@ -58,6 +64,7 @@ response from the ASF's legal counsel to
 Please read our [Legal FAQs](https://www.apache.org/legal/#user-links) first.
 
 <a name="ContactPoints-Other"></a>
+
 ### Other
 
 For more information on these and other foundation lists, see the [Mailing Lists](https://www.apache.org/foundation/mailinglists.html) page.

--- a/source/contributor-ladder.md
+++ b/source/contributor-ladder.md
@@ -8,13 +8,7 @@ project, from being a user, all the way up to being a maintainer of the
 project. While the specific details may look different from one project
 to another, the rungs of the ladder look mostly the same.
 
-* [User](#user)
-* [Contributor](#contributor)
-* [Committer](#committer)
-* [PMC Member](#pmc-member)
-* [ASF Member](#asf-member)
-* [Officers of the Foundation](#officers-of-the-foundation)
-* [Board of Directors](#board-of-directors)
+{{% toc %}}
 
 ## User
 

--- a/source/contributors/mailing-lists.md
+++ b/source/contributors/mailing-lists.md
@@ -8,6 +8,8 @@ communication format in projects. This is not merely because we've
 always done it that way, but is an intentional decision for the health
 and sustainability of our communities.
 
+{{% toc %}}
+
 ## Inclusion and transparency
 
 Mailing lists ensure that all members of the community can participate

--- a/source/pmc/_index.md
+++ b/source/pmc/_index.md
@@ -13,15 +13,7 @@ reports quarterly to the Board of Directors.
 The Board expects all PMCs to understand and comply with [published 
 policies](https://www.apache.org/dev/pmc.html#policy).
 
-- [PMC Responsibilities](#pmc-responsibilities)
-- [Chair](#chair)
-- [Voting](#voting)
-- [Infrastructure services](#infrastructure-services)
-- [Reporting](#reporting)
-- [Adding committers](#adding-committers)
-- [Community growth](#community-growth)
-- [Adding PMC members](#adding-pmc-members)
-- [What to do as a new member](#what-to-do-as-a-new-member)
+{{% toc %}}
 
 ## PMC Responsibilities
 

--- a/source/pmc/adding-committers.md
+++ b/source/pmc/adding-committers.md
@@ -15,6 +15,8 @@ In addition to the mechanisms for adding committers, give some thought
 to [practical steps you can take to attract new
 contributors](/pmc/community-growth.html).
 
+{{% toc %}}
+
 ## Who should be a committer?
 
 Each project must decide what is the correct measure for inviting a new

--- a/source/pmc/chair.md
+++ b/source/pmc/chair.md
@@ -15,6 +15,8 @@ peer, with a few additional duties.
 The Chair should be familiar with the [assigned
 duties](https://www.apache.org/dev/pmc.html#chair) of the role.
 
+{{% toc %}}
+
 ## Secretarial duties
 
 The Chair is responsible for completing the necessary "paperwork" when

--- a/source/pmc/community-growth.md
+++ b/source/pmc/community-growth.md
@@ -6,6 +6,8 @@ tags: ["pmc","committers","community"]
 Growing your project community takes work. This document makes practical
 suggestions of how to encourage people to get involved in your project.
 
+{{% toc %}}
+
 ## Publish a roadmap
 
 Volunteers can work on whatever they want, and so we have a tendency to

--- a/source/pmc/responsibilities.md
+++ b/source/pmc/responsibilities.md
@@ -8,11 +8,7 @@ of the project, including technical decisions, ensuring that the project
 is operating in accordance with ASF norms, adding new members to the
 project, and voting on releases.
 
-- [Conducting Business](#conducting-business)
-- [Protecting your brand](#protecting-your-brand)
-- [Making a release](#making-a-release)
-- [Ensuring Project Health](#ensuring-project-health)
-- [Adding Community Members](#adding-community-members)
+{{% toc %}}
 
 ## Conducting Business
 


### PR DESCRIPTION
I've added the toc macro (expands to layouts/shortcodes/toc.html) for any pages where it seemed useful, or could replace an existing manual TOC.

Please feel free to tweak before merging if there are improvements.