### PR TITLE
Deduplicate PMC/Committer addition stuff. 

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -59,7 +59,7 @@
             <a class="dropdown-item" href="/committers/funding-disclaimer.html">Funding Campaign Disclaimer</a>
             <a class="dropdown-item" href="/committers/good-first-issues.html">Good First Issues</a>
             <a class="dropdown-item" href="/pmc/">PMC Tips</a>
-            <a class="dropdown-item" href="/newcommitter.html">Recruiting New Committers</a>
+            <a class="dropdown-item" href="/pmc/community-growth.html">Recruiting New Contributors</a>
           </div>
         </li>
         <li class="nav-item dropdown">

--- a/source/committers/_index.md
+++ b/source/committers/_index.md
@@ -73,7 +73,7 @@ with. In most cases you will need to be a committer to carry out these
 activities, although non-committers can often act in supporting roles.
 
  * Write informational [blogs][22]
- * [Assessing and approving new committers](/newcommitter.html)
+ * [Assessing and approving new committers](/pmc/adding-committers.html)
  * [Board Reports](/boardreport.html)
  * [Apache Project Branding/Trademark Resources](https://www.apache.org/foundation/marks/resources)
 

--- a/source/newcommitter.md
+++ b/source/newcommitter.md
@@ -15,7 +15,7 @@ Some of the PMCs automatically make committers PMC members. The templates below
 have conditional `[if]` clauses for that.
 
 If the PMC has separate process for approving PMC members, see
-[new PMC member](newpmcmember.html).  
+[new PMC member](/pmc/adding-pmc-members.html).  
 The [Contributor Ladder](https://community.apache.org/contributor-ladder.html) helps explain different roles.
 
 {{% toc %}}
@@ -59,19 +59,44 @@ If they accept, then:
 <a name="NewCommitter-Guidelinesforassessingnewcandidatesforcommittership"></a>
 ## Guidelines for assessing new candidates for committership
 
-Frequently inviting new committers (and PMC members) to your project
-helps to ensure the sustainability of the project, and brings new ideas
-into the discussion.
+Each project must decide what is the correct measure for inviting a new
+committer to their project. There are, however, several things that we
+encourage you to consider.
 
-When voting, all PMC members need to make up their own minds as to whether a candidate
-should be approved to become a committer. They might search mailing lists and issue trackers to see
-how the candidate interacts with others, and the contributions (code or doc patches, suggestions, engagement in conversation) they have made.
+Any PMC member can (and should!) nominate project contributors for a
+committer vote. Don't assume that the PMC chair, or some senior project
+member, will do this. Watch the contributors, and nominate promising
+participants.
 
-All new committers **must** adhere to the [Apache Code of Conduct](https://www.apache.org/foundation/policies/conduct.html).
+Remember that we do all of our development in revision control.
+Errors are reversible learning opportunities. Thus, inviting someone
+"too early" has very little risk associated with it. On the other hand,
+inviting someone too late has the very real risk that they'll get
+frustrated and leave, and you'll have missed that opportunity forever.
+Setting the bar too high has been the eventual death of many projects.
 
-Each PMC may want to create their own supplemental committer guidelines,
-such as a minimum number of contributions, or number of months active on
-the project. We encourage you to not make this bar artificially high.
+Think of adding committers as an investment in the future of your
+project, rather than as a reward for good behavior. Committers whom you
+add today will be the backbone of your project tomorrow, or five years
+from now. New committers are the only way to ensure the long-term
+sustainability of your project. Look for contributors who seem to have
+new ways of thinking.
+
+Think of a committer as someone who is committed to the project, rather
+than just someone who writes code. Contributions in other areas, such as
+design, end-user support, event management, documentation, or project
+promotion, should also be welcomed into the project by inviting them as 
+committers, and, eventually, as PMC members.
+
+Finally, if you have specific requirements for committers (such as a
+period of time, or number of contributions) we encourage you to document
+that on your website. People like to know what their "career path" is in
+a project, rather than feeling that it is merely at the whim of a
+secret committee. If you see someone who seems to be on the path, point
+them to this document, so that they know what to expect, and what they
+can do to become a better contributor. See also [Becoming A
+Committer](https://community.apache.org/contributors/becomingacommitter.html)
+for general advice you might offer.
 
 The following are some points to consider when assessing a candidate's qualifications for committership.
 

--- a/source/pmc/adding-committers.md
+++ b/source/pmc/adding-committers.md
@@ -24,14 +24,16 @@ The [Contributor Ladder](https://community.apache.org/contributor-ladder.html) h
 ## TL;DR - Inviting a new Committer
 
 1. Discuss the proposed committer (and optionally PMC member). (Use
-   [this template](/templates/committer-discuss.txt).)
+   the [committer discuss template](/templates/committer-discuss.txt).)
 1. If the discussion seems to be going positively,
-   call a vote. (Use [this template](/templates/committer-vote.txt) for
-   committer, [this template](/templates/committer-pmc-vote.txt) for
+   call a vote. (Use the [committer vote template](/templates/committer-vote.txt) for
+   committer, the [committer + PMC member vote template](templates/committer-pmc-vote.txt) for
    committer and PMC member.)
-1. Close the vote. (Use [this template](/templates/committer-results.txt) for a committer vote, or [this template](/templates/committer-pmc-results.txt) for a committer + PMC member vote.)
-1. If the result is positive, invite the new committer. (Use [this
-   template](/templates/committer-invite.txt).)
+1. Close the vote. (Use the [committer vote results template](/templates/committer-results.txt) 
+   for a committer vote, or the [committer + PMC member vote results 
+   template](/templates/committer-pmc-results.txt) for a committer + PMC member vote.)
+1. If the result is positive, invite the new committer. (Use the
+   [committer invite template](/templates/committer-invite.txt).)
 
 If they accept, then:
 
@@ -47,12 +49,12 @@ If they accept, then:
       it to their ASF account.
    1. Add committer to the appropriate access groups for any services
       that your project uses, which are not tied to ASF LDAP.
-1. Notify the committer of completion. (Use [this
+1. Notify the committer of completion. (Use the [committer welcome
    template](/templates/committer-welcome.txt)
 1. If committer is also to be a PMC member, the PMC Chair or other PMC
    members must [update the PMC roster](https://whimsy.apache.org/roster/committee/)
    See [new PMC member](https://www.apache.org/dev/pmc.html#newpmcmember) for more detail.
-1. Announce the new committer. (Use [this
+1. Announce the new committer. (Use the [new committer announcement
   template](/templates/committer-announce.txt).
 
 
@@ -155,14 +157,14 @@ discussion. Any PMC member may propose a potential committer or PMC
 member. This is **not** the sole responsibility or right of the PMC
 chair.
 
-You can use [this template to start the
-discussion](/templates/committer-discuss.txt).
+You can use [the committer discussion template](/templates/committer-discuss.txt)
+to start the discussion
 
-We invite people to join as committers/PMC members, not github ids. It is
-fine to refer to the candidate's github id for context, but the person should
+We invite people to join as committers/PMC members, not GitHub ids. It is
+fine to refer to the candidate's GitHub id for context, but the person should
 be referred to by their name. It is not necessary to have their full legal
 name (that will be kept private) but it is important to use their name, as
-they refer to themselves in email. If a person is known only by their github
+they refer to themselves in email. If a person is known only by their GitHub
 id, it is ok to ask them for their real name prior to holding a VOTE.
 
 We need to be sure that they are committed people with whom we can work.
@@ -186,8 +188,8 @@ If the proposed candidate seems to be received positively by a majority
 of those responding, it's time to [start a vote](/templates/committer-vote.txt). 
 
 In some projects, new committers are automatically also made PMC members.
-If this is the case in your project, use [this template to start the
-vote](committer-pmc-vote.txt) instead.
+If this is the case in your project, use the [committer + PMC member vote
+template](committer-pmc-vote.txt) instead.
 
 Start a separate [VOTE] thread for each new person. This makes it much easier
 to review the email archives.
@@ -201,8 +203,8 @@ document](https://apache.org/foundation/voting).
 ### Announcing results
 
 After a positive result, record the result on the PMC list with a `[RESULT][VOTE]` subject
-and then invite the candidate, using [this template](/templates/committer-results.txt) 
-for a new committer, or [this template](/templates/committer-pmc-results.txt) 
+and then invite the candidate, using the [committer vote results template](/templates/committer-results.txt) 
+for a new committer, or the [committer + PMC member vote results template](/templates/committer-pmc-results.txt) 
 for a committer and PMC member.
 
 We give candidates a chance to decline committership 
@@ -211,10 +213,10 @@ in private. They can post a reply to the PMC mailing list.
 After we reach a decision on the `private@` list, and after the steps above, we
 [announce the new committer on the `dev` list](template/committer-announce.txt)
 
-Alternately, use [this template](/templates/committer-pmc-announce.txt) for new
+Alternately, use the [committer + PMC member announce template](/templates/committer-pmc-announce.txt) for new
 committer + PMC member.
 
-You can use [this template](/templates/committer-welcome.txt) to welcome
+You can use the [new committer welcome template](/templates/committer-welcome.txt) to welcome
 the new committer to your project community. You are, however,
 encouraged to create your own version of this template, customized to
 your particular project community.

--- a/source/pmc/adding-committers.md
+++ b/source/pmc/adding-committers.md
@@ -3,21 +3,61 @@ title: Adding Committers
 tags: ["pmc","committers"]
 ---
 
-The addition of committers is essential to the long-term 
-sustainability of an open source project. The PMC is responsible for
-determining who will be added as a committer.
+Identifying potential new committers, calling a vote for their recognition
+as a committer and processing the relevant documents are tasks to which
+the whole community can contribute.
 
-Please see the formal policy and process
-[documentation for adding committers](https://www.apache.org/dev/pmc.html#committer-management). 
-This page discusses best practices in how to think about new committers.
+Each project has a different approach to managing new committers. This page
+describes a common process found in many Apache projects. It also provides
+draft templates for the various communications that are necessary.
 
-In addition to the mechanisms for adding committers, give some thought
-to [practical steps you can take to attract new
-contributors](/pmc/community-growth.html).
+Some of the PMCs automatically make committers PMC members. The templates below
+have conditional `[if]` clauses for that.
+
+If the PMC has separate process for approving PMC members, see
+[new PMC member](/pmc/adding-pmc-members.html).  
+The [Contributor Ladder](https://community.apache.org/contributor-ladder.html) helps explain different roles.
 
 {{% toc %}}
 
-## Who should be a committer?
+<a name="NewCommitter-Summary"></a>
+## TL;DR - Inviting a new Committer
+
+1. Discuss the proposed committer (and optionally PMC member). (Use
+   [this template](/templates/committer-discuss.txt).)
+1. If the discussion seems to be going positively,
+   call a vote. (Use [this template](/templates/committer-vote.txt) for
+   committer, [this template](/templates/committer-pmc-vote.txt) for
+   committer and PMC member.)
+1. Close the vote. (Use [this template](/templates/committer-results.txt) for a committer vote, or [this template](/templates/committer-pmc-results.txt) for a committer + PMC member vote.)
+1. If the result is positive, invite the new committer. (Use [this
+   template](/templates/committer-invite.txt).)
+
+If they accept, then:
+
+1. If they already have an Apache id, grant appropriate commit privileges.
+   Use the Whimsy tool to update the roster via [Comitee Roster](https://whimsy.apache.org/roster/committee/) or
+   [PPMC Roster](https://whimsy.apache.org/roster/ppmc/)
+1. If they have already filed an ICLA, request creation of the committer account.
+   If they need to change anything in a previously filed ICLA, wait until the new ICLA is filed,
+   then request the account.
+   1. Wait until root says it is done
+   1. PMC Chair updates LDAP group membership which enables svn, gitbox and other access.
+      If the committer uses GitHub, let them know that they are responsible for linking 
+      it to their ASF account.
+   1. Add committer to the appropriate access groups for any services
+      that your project uses, which are not tied to ASF LDAP.
+1. Notify the committer of completion. (Use [this
+   template](/templates/committer-welcome.txt)
+1. If committer is also to be a PMC member, the PMC Chair or other PMC
+   members must [update the PMC roster](https://whimsy.apache.org/roster/committee/)
+   See [new PMC member](https://www.apache.org/dev/pmc.html#newpmcmember) for more detail.
+1. Announce the new committer. (Use [this
+  template](/templates/committer-announce.txt).
+
+
+<a name="NewCommitter-Guidelinesforassessingnewcandidatesforcommittership"></a>
+## Guidelines for assessing new candidates for committership
 
 Each project must decide what is the correct measure for inviting a new
 committer to their project. There are, however, several things that we
@@ -58,29 +98,164 @@ can do to become a better contributor. See also [Becoming A
 Committer](https://community.apache.org/contributors/becomingacommitter.html)
 for general advice you might offer.
 
-## Vote process
+The following are some points to consider when assessing a candidate's qualifications for committership.
 
-The complete policy and procedure around *how* to vote for a committer,
-and how to add them to the relevant rosters if and when they are voted
-in, is covered in the [PMC policy
-document](https://www.apache.org/dev/pmc.html#committer-management). As
-a PMC member, you should read and understand that document.
+<a name="NewCommitter-Abilitytoworkco-operativelywithpeers."></a>
+### Ability to work cooperatively with peers.
+How do we evaluate?
 
-## What to do when a committer is elected
+  - By the interactions they have through email.
+  - By how they respond to criticism.
+  - By how they participate in the group decision-making process.
 
-Once a committer has been added to the roster, be sure that they
-understand how things work in your project, rather than leaving them to
-figure this out on their own.
+<a name="NewCommitter-Abilitytobeamentor."></a>
+### Ability to be a mentor.
+How do we evaluate?
 
-Point them to specific review processes that they are expected to abide
-by before committing or merging a change.
+  - By the interactions they have through email.
+  - By how clear they are and how willing they are to identify or even create appropriate background
+materials.
 
-Point new committers to [Infra's guide for new
-committers](https://infra.apache.org/new-committers-guide.html), which
-has general information for all ASF committers.
+<a name="NewCommitter-Community"></a>
+### Community
+How do we evaluate?
 
-Consider clearly documenting the development environment that a
-committer needs to be successful. This might include a
-recommended IDE, how to interact with your CI/CD stack, how to build and
-test locally, and any common problems they might encounter with their
-first few commits.
+  - By the interactions they have through email.
+  - Do they help to answer questions raised on the mailing list; do they show a helpful
+attitude and respect for other people's ideas?
+
+<a name="NewCommitter-Committment"></a>
+### Commitment
+How do we evaluate?
+
+  - By time already given to the project.
+  - By how well they stick with the process through tough issues.
+  - By how they help on not-so-fun tasks.
+
+<a name="NewCommitter-Personalskill/ability"></a>
+### Personal skill/ability
+How do we evaluate?
+
+  - A solid general understanding of the project.
+  - Quality of discussion in email.
+  - Whether their patches (where applicable) are easy to apply with only a cursory review.
+
+<a name="NewCommitter-NewCommitterProcess"></a>
+## New Committer Process
+
+This section describes a typical Apache project's process for handling the
+vote to add a new committer. Templates mentioned in the process appear
+later in this document.
+
+<a name="NewCommitter-Discussion"></a>
+### Discussion
+
+We do the discussion and vote on the `private@` mailing list to enable a frank
+discussion. Any PMC member may propose a potential committer or PMC
+member. This is **not** the sole responsibility or right of the PMC
+chair.
+
+You can use [this template to start the
+discussion](/templates/committer-discuss.txt).
+
+We invite people to join as committers/PMC members, not github ids. It is
+fine to refer to the candidate's github id for context, but the person should
+be referred to by their name. It is not necessary to have their full legal
+name (that will be kept private) but it is important to use their name, as
+they refer to themselves in email. If a person is known only by their github
+id, it is ok to ask them for their real name prior to holding a VOTE.
+
+We need to be sure that they are committed people with whom we can work.
+They will be our peers. We will have already observed that they are
+committed to the project and graceful toward users and other developers.
+
+Don't wait too long before proposing and don't be too hasty. There is a
+trade-off and something about timeliness. A point is reached where it
+becomes obvious that we should invite them. This encourages them and keeps
+them enthusiastic. If we leave it too long, then we risk them becoming
+disillusioned.
+
+On the `private@` list we can each say exactly what we feel about each person,
+with no holds barred. Keep the discussion concise. The praise part can
+be done later in public. Keep in mind, however, that if the member becomes
+a PMC member later, they will have access to this discussion.
+
+### Vote
+
+If the proposed candidate seems to be received positively by a majority
+of those responding, it's time to [start a vote](/templates/committer-vote.txt). 
+
+In some projects, new committers are automatically also made PMC members.
+If this is the case in your project, use [this template to start the
+vote](committer-pmc-vote.txt) instead.
+
+Start a separate [VOTE] thread for each new person. This makes it much easier
+to review the email archives.
+
+Let the Vote thread run for one week.
+
+A positive result is achieved when there are at least 3 +1 votes and no vetoes,
+as per the [ASF voting process
+document](https://apache.org/foundation/voting).
+
+### Announcing results
+
+After a positive result, record the result on the PMC list with a `[RESULT][VOTE]` subject
+and then invite the candidate, using [this template](/templates/committer-results.txt) 
+for a new committer, or [this template](/templates/committer-pmc-results.txt) 
+for a committer and PMC member.
+
+We give candidates a chance to decline committership 
+in private. They can post a reply to the PMC mailing list.
+
+After we reach a decision on the `private@` list, and after the steps above, we
+[announce the new committer on the `dev` list](template/committer-announce.txt)
+
+Alternately, use [this template](/templates/committer-pmc-announce.txt) for new
+committer + PMC member.
+
+You can use [this template](/templates/committer-welcome.txt) to welcome
+the new committer to your project community. You are, however,
+encouraged to create your own version of this template, customized to
+your particular project community.
+
+Other notes about the process are available on the main 
+[Apache site](https://www.apache.org/dev/pmc.html#newcommitter).
+
+### Committer Account Creation
+Please see the [account creation instructions](https://www.apache.org/dev/pmc.html#newcommitter).
+
+In summary:
+
+If the ICLA identifies the project and a valid Apache ID, and the
+`[RESULT][VOTE]` message has been posted to the PMC private list,
+the account creation request is made by the
+secretary or assistant secretary who files the ICLA.
+
+Otherwise, the new account request should be made by the
+PMC Chair (or any [ASF Member](https://www.apache.org/foundation/glossary.html#Member)
+if the chair is unavailable).
+
+The PMC chair needs to use the [ASF New Account Request](https://id.apache.org/acreq/pmc-chairs/) form to
+send a new account request. Members may use [ASF New Account Request](https://id.apache.org/acreq/members/) page.
+
+Please supply the [mail archives](https://lists.apache.org/) URL as
+proof of the vote results.
+
+<a name="NewCommitter-EmailTemplates"></a>
+## Email Templates
+
+The following templates are recommended ways to phrase your email
+communications around inviting a new committer, to ensure that everyone
+understands your intent.
+
+* [Committer discussion template](/templates/committer-discuss.txt)
+* [Committer vote template](/templates/committer-vote.txt)
+* [Committer + PMC vote template](/templates/committer-pmc-vote.txt)
+* [Committer vote results template](/templates/committer-results.txt)
+* [Committer + PMC vote results template](/templates/committer-pmc-results.txt)
+* [Committer invite template](/templates/committer-invite.txt)
+* [New committer announcement](/templates/committer-announce.txt)
+* [New committer and PMC member announcement](/templates/committer-pmc-announce.txt)
+* [Welcome the new committer to your community](/templates/committer-welcome.txt)
+

--- a/source/pmc/adding-pmc-members.md
+++ b/source/pmc/adding-pmc-members.md
@@ -3,16 +3,111 @@ title: Adding PMC members
 tags: ["pmc","election"]
 ---
 
-The PMC is responsible for identifying individuals who should be added
-to the PMC. This is a critical part of the long-term health and
-sustainability of a project, and ensures that contributors to the
-project have a voice in the project's roadmap.
+This document describes a typical Apache project's process for handling the
+vote to add a new PMC (Project Management Committee) member - when it is
+separate from becoming committer.
 
-* Who should be a PMC member?
-* Nominating, discussion, and voting
-* What to do when a new PMC member is elected
+Templates mentioned in the process appear [#NewPMCMember-EmailTemplates](later in 
+this document). If your PMC adds automatically committers as PMC members, the process
+for doing both at the same time is described in the [New 
+committer](https://community.apache.org/pmc/adding-committers.html) advice.
 
-Note: Formal policy/process doc is here: https://www.apache.org/dev/pmc.html#newpmc
+The [Contributor Ladder](https://community.apache.org/contributor-ladder.html) helps 
+explain different roles.
 
+{{% toc %}}
 
+<a name="NewPMCMember-Summary"></a>
+## TL;DR - Inviting a new PMC member
+
+1. Discuss the proposed PMC member.  (Use [this template](/templates/pmc-member-discuss.txt).)
+1. If the discussion seems to be going positively, call a vote. (Use
+   [this template](/templates/pmc-member-vote.txt).)
+1. Close the vote. (Use [this template](/templates/pmc-member-results.txt).)
+1. If the result is positive, invite the new committer. (Use [this
+   template](/templates/pmc-member-invite.txt).)
+
+If they accept, then:
+
+1. If the new PMC member is already is already a committer, and they have Apache id,
+   you should grant them appropriate PMC privileges. Use the 
+   [committee roster tool](https://whimsy.apache.org/roster/committee/) (or
+   [ppmc roster tool](https://whimsy.apache.org/roster/ppmc/) for
+   incubating projects) on Whimsy to update the roster.
+1. Announce the new PMC member. (Use [this
+   template](/templates/pmc-member-announce.txt).)
+
+<a name="#NewPMCMemberGuidelines"></a>
+## Guidelines for inviting a new PMC member
+
+Frequently adding new PMC members to your project helps to ensure the
+sustainability and longevity of your project, and brings new ideas into
+the discussion.
+
+As a PMC member, you should frequently look at your
+project's active committers and contributors (including non-code
+participants) and consider whether having their voice in the
+decision-making process would better serve your stakeholders, and
+contribute to the Foundation's mission of providing software for the
+public good.
+
+<a name="NewPMCMember-Discussion"></a>
+### Discussion
+
+Any PMC member may propose a potential PMC member.
+This is **not** the sole responsibility or right of the PMC chair.
+
+We do the discussion and vote on the `private@` mailing list to enable a frank
+discussion. But do keep in mind that if the candidate is elected, they
+will be able to inspect the archives, so keep your discussion respectful
+and professional, with that in mind.
+
+We invite people to join as PMC members, not github ids. It is
+fine to refer to the candidate's github id for context, but the person should
+be referred to by their name. It is not necessary to have their full legal
+name (that will be kept private) but it is important to use their name, as
+they refer to themselves in email. If a person is known only by their github
+id, it is ok to ask them for their real name prior to holding a VOTE.
+
+### Vote
+
+Start a separate [VOTE] thread for each new person. This makes it much easier
+to review the email archives.
+
+We need to be sure that they are committed people with whom we can work.
+They will be our peers. We will have already observed that they are
+committed to the project and graceful toward users and other developers.
+
+Don't wait too long before proposing and don't be too hasty. There is a
+trade-off and something about timeliness. A point is reached where it
+becomes obvious that we should invite them. This encourages them and keeps
+them enthusiastic. If we leave it too long, then we risk them becoming
+disillusioned.
+
+Let the Vote thread run for one week.
+
+A positive result is achieved when there are at least 3 +1 votes and no vetoes,
+as per the [ASF voting process
+document](https://apache.org/foundation/voting).
+
+### Invitation and welcome
+
+After a positive result, record the result on the PMC list with a `[RESULT][VOTE]` subject
+and then invite the candidate. We give candidates a chance to decline PMC membership in private.
+They can post a reply to the PMC mailing list.
+
+After we reach a decision on the `private@` list, and after the steps above, we
+announce the new PMC member on the `dev` list. We can then each follow up with
+our praise and welcome messages in public.
+
+Other notes about the process are available on the main [Apache site](https://www.apache.org/dev/pmc.html#newpmcmember).
+
+<a name="NewPMCMember-EmailTemplates"></a>
+## Email Templates
+
+* [PMC member vote](/templates/pmc-member-vote.txt)
+* [PMC member vote results](/templates/pmc-member-results.txt)
+* [PMC member invitation](/templates/pmc-member-invite.txt)
+* [PMC member announcmement](/templates/pmc-member-announce.txt)
+* [PMC member welcome](/templates/pmc-member-welcome.txt)
 

--- a/source/templates/committer-pmc-vote.txt
+++ b/source/templates/committer-pmc-vote.txt
@@ -3,12 +3,6 @@ Subject: [VOTE] New Committer and PMC member: [Candidate Name]
 
 [ add the reasons behind your nomination here ]
 
-Voting ends one week from today, i.e. midnight UTC on YYYY-MM-DD
-https://www.timeanddate.com/counters/customcounter.html?year=YYYY&month=MM&day=DD
-
-See voting guidelines at
-https://community.apache.org/newcommitter.html
-
 This is a VOTE to add [Candidate Name] as a committer and PMC member
 
 This has been discussed here: [Link to DISCUSS thread on
@@ -23,5 +17,5 @@ Voting ends one week from today, i.e. midnight UTC on YYYY-MM-DD
 https://www.timeanddate.com/counters/customcounter.html?year=YYYY&month=MM&day=DD
 
 See voting guidelines at
-https://community.apache.org/newcommitter.html
+https://community.apache.org/pmc/adding-committers.html
 

--- a/source/templates/committer-vote.txt
+++ b/source/templates/committer-vote.txt
@@ -15,5 +15,5 @@ Voting ends one week from today, i.e. midnight UTC on YYYY-MM-DD
 https://www.timeanddate.com/counters/customcounter.html?year=YYYY&month=MM&day=DD
 
 See voting guidelines at
-https://community.apache.org/newcommitter.html
+https://community.apache.org/pmc/adding-committers.html
 

--- a/source/templates/pmc-member-vote.txt
+++ b/source/templates/pmc-member-vote.txt
@@ -16,5 +16,5 @@ Voting ends one week from today, i.e. midnight UTC on YYYY-MM-DD
 https://www.timeanddate.com/counters/customcounter.html?year=YYYY&month=MM&day=DD
 
 See voting guidelines at
-https://community.apache.org/newpmcmember.html
+https://community.apache.org/pmc/adding-pmc-members.html
 

--- a/static/.htaccess
+++ b/static/.htaccess
@@ -25,3 +25,6 @@ Redirect /committers/lazyConsensus.html /committers/decisionMaking.html
 Redirect /speakers/speakers.html /speakers/
 
 Redirect /working-groups/ /workinggroups/
+
+RedirectMatch ^/newpmcmember(\.html)? /pmc/adding-pmc-members.html
+RedirectMatch ^/newcommitter(\.html)? /pmc/adding-committers.html


### PR DESCRIPTION
Deduplicates new committer and new pmc member documentation. Redirects old URLs. Updates various links to and from these documents to compensate for new location.
The New Committer doc is a straight move. The New PMC Member doc consolidates content from two versions of this doc, and so could probably use some additional editing or wordsmithing.
Resolves COMDEV-551, COMDEV-552, and COMDEV-555