### PR TITLE
Add trademark and branding terms to the Maturity Model

### DIFF
--- a/source/apache-way/apache-project-maturity-model.md
+++ b/source/apache-way/apache-project-maturity-model.md
@@ -197,6 +197,55 @@ The project strives to answer user questions in a timely manner.
 </dd>
 </dl>
 
+## Trademark and Branding
+
+Notable items from the [Trademark Policy][trademark-policy],
+[FAQ][trademark-faq], [Guide][trademark-guide], and
+[PMC Branding Responsibilities][branding-responsibilities].
+The project's PMC should comply with ASF's branding and trademark policy in
+all places it controls.
+
+[trademark-policy]: https://www.apache.org/foundation/marks/
+[trademark-faq]: https://www.apache.org/foundation/marks/faq/
+[trademark-guide]: https://www.apache.org/foundation/marks/guide
+[branding-responsibilities]: https://www.apache.org/foundation/marks/responsibility
+
+<dl>
+<dt id="TB10">TB10</dt>
+<dd>
+The project correctly uses "Apache Foo" as the project name
+where required.
+</dd>
+
+<dt id="TB20">TB20</dt>
+<dd>
+The project resolves any potential trademark issue pointed out to
+it promptly.
+</dd>
+
+<dt id="TB30">TB30</dt>
+<dd>
+The project proactively monitors 3rd party use of its trademarks,
+addressing any instances of misuse.
+
+NB. For example, regularly/irregularly check how downstream
+refer to the project, check how 3rd party sites refer to the project.
+</dd>
+
+<dt id="TB40">TB40</dt>
+<dd>
+Any existing previous domain name relating to the project name is
+under the PMC's control.
+</dd>
+
+<dt id="TB50">TB50</dt>
+<dd>
+Any existing trademarks relating to the project name have been or
+are in the process of being transferred to the ASF.
+</dd>
+
+</dl>
+
 ## Consensus Building
 
 <dl>
@@ -213,16 +262,16 @@ Decisions require a consensus among PMC members
 <sup><a href="#fnref-08fda1a3461c11086b8542178f35e0c27a4a46c3" id="fndef-08fda1a3461c11086b8542178f35e0c27a4a46c3-8">9</a></sup>
  and are documented on the project's main communications channel.
 The PMC takes community opinions into account, but the PMC has the final word.
- </dd>
+</dd>
 
- <dt id="CS30">CS30</dt>
- <dd>
- The project uses documented voting rules to build consensus when discussion is not sufficient.
- <sup><a href="#fnref-9b0cf71f04bcd81dddbf6199f1c771e27566611e" id="fndef-9b0cf71f04bcd81dddbf6199f1c771e27566611e-9">10</a></sup>
- </dd>
+<dt id="CS30">CS30</dt>
+<dd>
+The project uses documented voting rules to build consensus when discussion is not sufficient.
+<sup><a href="#fnref-9b0cf71f04bcd81dddbf6199f1c771e27566611e" id="fndef-9b0cf71f04bcd81dddbf6199f1c771e27566611e-9">10</a></sup>
+</dd>
 
- <dt id="CS40">CS40</dt>
- <dd>In Apache projects, vetoes are only valid for code commits. The person exercising the veto must justify it with a technical explanation, as per the Apache voting rules
+<dt id="CS40">CS40</dt>
+<dd>In Apache projects, vetoes are only valid for code commits. The person exercising the veto must justify it with a technical explanation, as per the Apache voting rules
 defined in CS30.
 </dd>
 
@@ -286,6 +335,8 @@ v1.1, October 2016 added RE50.
 v1.2, February 2018, reworked the "how to use" section with more links to self-assessments.
 
 v1.3, June 2021, improve readability and simplify the language where possible.
+
+v1.4, December 2024, added the Trademark and Branding section (TB10-TB50).
 
 See the <a href="https://svn.apache.org/viewvc/comdev/site/trunk/content/apache-way/apache-project-maturity-model.mdtext?view=log" target="_blank">svn revision history</a> (for older
 versions) and <a href="https://github.com/apache/comdev-site/commits/main/source/apache-way/apache-project-maturity-model.md">GitHub history</a> (since March 2020) of this document for more details and other minor changes.

--- a/source/apache-way/apache-project-maturity-model.md
+++ b/source/apache-way/apache-project-maturity-model.md
@@ -213,37 +213,43 @@ all places it controls.
 <dl>
 <dt id="TB10">TB10</dt>
 <dd>
-The project correctly uses "Apache Foo" as the project name
-where required.
+The project uses "Apache Foo™" as the project and software product
+name consistently, with appropriate [trademark attributions][trademark-attributions].
 </dd>
+
+[trademark-attributions]: https://apache.org/foundation/marks/pmcs#attributions
 
 <dt id="TB20">TB20</dt>
 <dd>
-The project resolves any potential trademark issue pointed out to
-it promptly.
+The project's primary homepage is at `projectname.apache.org`.
+When exceptions exist to use alternate domains for any purpose, any
+`non-apache.org` domain names are owned by the ASF.
 </dd>
 
 <dt id="TB30">TB30</dt>
 <dd>
-The project proactively monitors 3rd party use of its trademarks,
-addressing any instances of misuse.
+The ASF has trademark rights, including any registrations, to the
+project name, logo, and any other major branding elements.
 
-NB. For example, regularly/irregularly check how downstream
-refer to the project, check how 3rd party sites refer to the project.
+NB. For example, any transfers of existing trademark registrations
+during Incubation must completed before graduation.
 </dd>
 
 <dt id="TB40">TB40</dt>
 <dd>
-Any existing previous domain name relating to the project name is
-under the PMC's control.
-</dd>
+The project monitors for any major misuses of their project's brand
+by others, and [reports][reports-trademark-issues] any potential
+misuses to Brand Management.
 
-<dt id="TB50">TB50</dt>
-<dd>
-Any existing trademarks relating to the project name have been or
-are in the process of being transferred to the ASF.
-</dd>
+NB. TB40 is a balancing act: we hope that PMCs are spending some
+time responding to any obvious or blatant misuses of their brand.
+But PMCs sometimes can't handle all the details of actually stopping a
+potential infringement; what we really need is for PMCs to actively
+report them, and then promptly respond if Brand Managment (or other
+officers) ask for information when addressing a misuse.
 
+[reports-trademark-issues]: https://apache.org/foundation/marks/reporting.html#pmcs
+</dd>
 </dl>
 
 ## Consensus Building

--- a/source/apache-way/apache-project-maturity-model.md
+++ b/source/apache-way/apache-project-maturity-model.md
@@ -304,10 +304,11 @@ It might be useful for top-level ASF projects to regularly assess their maturity
 
 Here are a few self-assessment examples:
 
-* [Apache Groovy podling self-assessment, 2015](https://github.com/apache/groovy/blob/576b3c5d6a7022ac4a8df1ef118666456ce627fb/MATURITY.adoc)
-* [Apache Taverna Graduation Maturity Assessment, 2016](https://cwiki.apache.org/confluence/display/TAVERNADEV/2016-03+Taverna+Graduation+Maturity+Assessment)
-* [Apache CarbonData Podling Maturity Assessment, 2017](https://cwiki.apache.org/confluence/display/CARBONDATA/Apache+Maturity+Model+Assessment+for+CarbonData)
+* [Apache OpenDAL Maturity Model Assessment, 2024](https://opendal.apache.org/community/maturity)
 * [Apache ServiceComb Maturity Model Assessment, 2018](https://cwiki.apache.org/confluence/display/SERVICECOMB/Apache+Maturity+Model+Assessment+for+ServiceComb)
+* [Apache CarbonData Podling Maturity Assessment, 2017](https://cwiki.apache.org/confluence/display/CARBONDATA/Apache+Maturity+Model+Assessment+for+CarbonData)
+* [Apache Taverna Graduation Maturity Assessment, 2016](https://cwiki.apache.org/confluence/display/TAVERNADEV/2016-03+Taverna+Graduation+Maturity+Assessment)
+* [Apache Groovy podling self-assessment, 2015](https://github.com/apache/groovy/blob/576b3c5d6a7022ac4a8df1ef118666456ce627fb/MATURITY.adoc)
 
 ## Other Open Source Project Models
 

--- a/source/apache-way/apache-project-maturity-model.md
+++ b/source/apache-way/apache-project-maturity-model.md
@@ -197,63 +197,6 @@ The project strives to answer user questions in a timely manner.
 </dd>
 </dl>
 
-## Trademark and Branding
-
-Notable items from the [Trademark Policy][trademark-policy],
-[FAQ][trademark-faq], [Guide][trademark-guide], and
-[PMC Branding Responsibilities][branding-responsibilities].
-The project's PMC should comply with ASF's branding and trademark policy in
-all places it controls.
-
-[trademark-policy]: https://www.apache.org/foundation/marks/
-[trademark-faq]: https://www.apache.org/foundation/marks/faq/
-[trademark-guide]: https://www.apache.org/foundation/marks/guide
-[branding-responsibilities]: https://www.apache.org/foundation/marks/responsibility
-
-<dl>
-<dt id="TB10">TB10</dt>
-<dd>
-The project uses "Apache Foo™" as the project and software product
-name consistently, with appropriate [trademark attributions][trademark-attributions].
-</dd>
-
-[trademark-attributions]: https://apache.org/foundation/marks/pmcs#attributions
-
-<dt id="TB20">TB20</dt>
-<dd>
-The project's primary homepage is at <code>projectname.apache.org</code>.
-When exceptions exist to use alternate domains for any purpose, any
-<code>non-apache.org</code> domain names are owned by the ASF.
-</dd>
-
-<dt id="TB30">TB30</dt>
-<dd>
-The ASF has trademark rights, including any registrations, to the
-project name, logo, and any other major branding elements.
-
-<br/><br/>
-<em>NB.</em> For example, any transfers of existing trademark registrations
-during Incubation must completed before graduation.
-</dd>
-
-<dt id="TB40">TB40</dt>
-<dd>
-The project monitors for any major misuses of their project's brand
-by others, and [reports][reports-trademark-issues] any potential
-misuses to Brand Management.
-
-<br/><br/>
-<em>NB.</em> TB40 is a balancing act: we hope that PMCs are spending some
-time responding to any obvious or blatant misuses of their brand.
-But PMCs sometimes can't handle all the details of actually stopping a
-potential infringement; what we really need is for PMCs to actively
-report them, and then promptly respond if Brand Managment (or other
-officers) ask for information when addressing a misuse.
-
-[reports-trademark-issues]: https://apache.org/foundation/marks/reporting.html#pmcs
-</dd>
-</dl>
-
 ## Consensus Building
 
 <dl>
@@ -306,6 +249,50 @@ The project is independent from any corporate or organizational influence.
 </dd>
 </dl>
 
+## Trademark and Branding
+
+Notable items from the [Trademark Policy][trademark-policy],
+[FAQ][trademark-faq], [Guide][trademark-guide], and
+[PMC Branding Responsibilities][branding-responsibilities].
+The project's PMC should comply with ASF's branding and trademark policy in
+all places it controls.
+
+[trademark-policy]: https://www.apache.org/foundation/marks/
+[trademark-faq]: https://www.apache.org/foundation/marks/faq/
+[trademark-guide]: https://www.apache.org/foundation/marks/guide
+[branding-responsibilities]: https://www.apache.org/foundation/marks/responsibility
+
+<dl>
+<dt id="TB10">TB10</dt>
+<dd>
+The project uses "Apache Foo™" as the project and software product
+name consistently, with appropriate trademark attributions
+<sup><a href="#fnref-0178A90B3010DC18C1BF45A9E55CB9C54D42F14B" id="fndef-0178A90B3010DC18C1BF45A9E55CB9C54D42F14B-12">13</a></sup>.
+</dd>
+
+<dt id="TB20">TB20</dt>
+<dd>
+The project's primary homepage is at <code>projectname.apache.org</code>.
+When exceptions exist to use alternate domains for any purpose, any
+<code>non-apache.org</code> domain names are owned by the ASF.
+</dd>
+
+<dt id="TB30">TB30</dt>
+<dd>
+The ASF has trademark rights, including any registrations, to the
+project name, logo, and any other major branding elements
+<sup><a href="#fnref-CAE17AF182EE90ACCB55FE618A99E4AECC282572" id="fndef-CAE17AF182EE90ACCB55FE618A99E4AECC282572-13">14</a></sup>.
+</dd>
+
+<dt id="TB40">TB40</dt>
+<dd>
+The project monitors for any major misuses of their project's brand
+by others, and reports
+<sup><a href="#fnref-7052346662809FE3100C7E3C1F1CB33D0B10208D" id="fndef-7052346662809FE3100C7E3C1F1CB33D0B10208D-14">15</a></sup>
+any potential misuses to Brand Management.
+</dd>
+</dl>
+
 # How To Use The Apache Project Maturity Model
 
 **Remember:** This model is a guide; it is not a requirements document. The model shows what generally good behaviors in an Apache project look like.
@@ -352,7 +339,6 @@ versions) and <a href="https://github.com/apache/comdev-site/commits/main/source
 ### Footnotes
 
 <ol>
-
 <li>
 <a id="fnref-a2e0cd066fd8f45af4e87bcdbf8d9abd3ad40872"></a>
 "For distribution to the public at no charge" is straight from the from the ASF Bylaws at <a class="http" href="https://apache.org/foundation/bylaws.html" target="_blank">https://apache.org/foundation/bylaws.html</a>.
@@ -391,43 +377,43 @@ contributions but grant the ASF a perpetual copyright license for them.
 (<a href="#fndef-258df7a61c975c67bbef17d3cf7851bafd40b8fb-4">5</a>)
 </li>
 
- <li>
- <a id="fnref-d2389850862fcc9bddabb3c2e23b13922d68e3fc"></a>
- See <a class="http" href="https://www.apache.org/legal/release-policy.html">https://www.apache.org/legal/release-policy.html</a> for more info on Apache releases.
+<li>
+<a id="fnref-d2389850862fcc9bddabb3c2e23b13922d68e3fc"></a>
+See <a class="http" href="https://www.apache.org/legal/release-policy.html">https://www.apache.org/legal/release-policy.html</a> for more info on Apache releases.
 
- (<a href="#fndef-d2389850862fcc9bddabb3c2e23b13922d68e3fc-5">6</a>)
- </li>
+(<a href="#fndef-d2389850862fcc9bddabb3c2e23b13922d68e3fc-5">6</a>)
+</li>
 
- <li>
- <a id="fnref-89a5257606b929cc5ced2bee207c80b43541d488"></a>
- The required level of security depends on the software's intended uses, of course. Projects should clearly document security expectations.
+<li>
+<a id="fnref-89a5257606b929cc5ced2bee207c80b43541d488"></a>
+The required level of security depends on the software's intended uses, of course. Projects should clearly document security expectations.
 
- (<a href="#fndef-89a5257606b929cc5ced2bee207c80b43541d488-6">7</a>)
- </li>
+(<a href="#fndef-89a5257606b929cc5ced2bee207c80b43541d488-6">7</a>)
+</li>
 
- <li>
- <a id="fnref-7c23a24b04dcf9b4b10423685fbd37f69b2b3783"></a>
- Apache projects can just point to <a class="http" href="https://www.apache.org/security/">https://www.apache.org/security/</a> or use their own security contacts page, which should also point to that.
+<li>
+<a id="fnref-7c23a24b04dcf9b4b10423685fbd37f69b2b3783"></a>
+Apache projects can just point to <a class="http" href="https://www.apache.org/security/">https://www.apache.org/security/</a> or use their own security contacts page, which should also point to that.
 
- (<a href="#fndef-7c23a24b04dcf9b4b10423685fbd37f69b2b3783-7">8</a>)
- </li>
+(<a href="#fndef-7c23a24b04dcf9b4b10423685fbd37f69b2b3783-7">8</a>)
+</li>
 
- <li>
- <a id="fnref-08fda1a3461c11086b8542178f35e0c27a4a46c3"></a>
- In Apache projects, "consensus" means <em>widespread agreement among people who have decision power</em>. It does not necessarily mean "unanimity".
+<li>
+<a id="fnref-08fda1a3461c11086b8542178f35e0c27a4a46c3"></a>
+In Apache projects, "consensus" means <em>widespread agreement among people who have decision power</em>. It does not necessarily mean "unanimity".
 
- (<a href="#fndef-08fda1a3461c11086b8542178f35e0c27a4a46c3-8">9</a>)
- </li>
+(<a href="#fndef-08fda1a3461c11086b8542178f35e0c27a4a46c3-8">9</a>)
+</li>
 
- <li>
- <a id="fnref-9b0cf71f04bcd81dddbf6199f1c771e27566611e"></a>
- For Apache projects, <a class="http" href="https://www.apache.org/foundation/voting.html" target="_blank">https://www.apache.org/foundation/voting.html</a> defines the voting rules.
+<li>
+<a id="fnref-9b0cf71f04bcd81dddbf6199f1c771e27566611e"></a>
+For Apache projects, <a class="http" href="https://www.apache.org/foundation/voting.html" target="_blank">https://www.apache.org/foundation/voting.html</a> defines the voting rules.
 
- (<a href="#fndef-9b0cf71f04bcd81dddbf6199f1c771e27566611e-9">10</a>)
- </li>
+(<a href="#fndef-9b0cf71f04bcd81dddbf6199f1c771e27566611e-9">10</a>)
+</li>
 
- <li>
- <a id="fnref-d9e7a517f046358463f038f3830fef171e69f78b"></a>
+<li>
+<a id="fnref-d9e7a517f046358463f038f3830fef171e69f78b"></a>
 Each Apache project has a private mailing list that its PMC is expected to use
 only when really needed. The private list is typically used for
 discussions about people, for example to discuss and to vote on PMC
@@ -445,4 +431,34 @@ with no hidden agendas.
 (<a href="#fndef-764b2c2fd32deb4ff73ea01efa67c8556303c359-11">12</a>)
 </li>
 
+<li>
+<a id="fnref-0178A90B3010DC18C1BF45A9E55CB9C54D42F14B"></a>
+See https://apache.org/foundation/marks/pmcs#attributions for more information
+on trademark attributions.
+
+(<a href="#fndef-0178A90B3010DC18C1BF45A9E55CB9C54D42F14B-12">13</a>)
+</li>
+
+<li>
+<a id="fnref-CAE17AF182EE90ACCB55FE618A99E4AECC282572"></a>
+For example, any transfers of existing trademark registrations during
+Incubation must completed before graduation.
+
+(<a href="#fndef-CAE17AF182EE90ACCB55FE618A99E4AECC282572-13">14</a>)
+</li>
+
+<li>
+<a id="fnref-7052346662809FE3100C7E3C1F1CB33D0B10208D"></a>
+See also https://apache.org/foundation/marks/reporting.html#pmcs for
+more information on reporting misuses.
+
+TB40 is a balancing act: we hope that PMCs are spending some
+time responding to any obvious or blatant misuses of their brand.
+But PMCs sometimes can't handle all the details of actually stopping a
+potential infringement; what we really need is for PMCs to actively
+report them, and then promptly respond if Brand Managment (or other
+officers) ask for information when addressing a misuse.
+
+(<a href="#fndef-7052346662809FE3100C7E3C1F1CB33D0B10208D-14">15</a>)
+</li>
 </ol>

--- a/source/apache-way/apache-project-maturity-model.md
+++ b/source/apache-way/apache-project-maturity-model.md
@@ -15,7 +15,7 @@ It does not describe all the details of how our projects operate, but aims to ca
 
 Contrary to other maturity models, we do not define staged partial compliance levels. A mature Apache project complies with all the elements of this model, and other projects are welcome to adopt the elements that suit their goals.
 
-Note that we try to avoid using the word "must" below. The model describes the state of a mature project, as opposed to a set of rules. 
+Note that we try to avoid using the word "must" below. The model describes the state of a mature project, as opposed to a set of rules.
 
 Projects which incubate at the ASF might not fit into all the parts of this model; however a major goal of incubation is to bring the project's community closer to it.
 
@@ -23,7 +23,7 @@ We welcome questions and feedback about this model on the <a href="https://lists
 
 # The Apache Project Maturity Model
 
-Each item in the model has a unique ID to allow it to be easily referenced elsewhere. 
+Each item in the model has a unique ID to allow it to be easily referenced elsewhere.
 
 ## Code
 
@@ -36,7 +36,7 @@ The project produces Open Source software for distribution to the public, at no 
 
 <dt id="CD20">CD20</dt>
 <dd>
-Anyone can easily discover and access the project's code. 
+Anyone can easily discover and access the project's code.
 </dd>
 
 <dt id="CD30">CD30</dt>
@@ -46,17 +46,16 @@ Anyone using standard, widely-available tools, can build the code in a reproduci
 
 <dt id="CD40">CD40</dt>
 <dd>
-The full history of the project's code is available via a source code 
-control system, in a way that allows anyone to recreate any released version. 
+The full history of the project's code is available via a source code
+control system, in a way that allows anyone to recreate any released version.
 </dd>
 
 <dt id="CD50">CD50</dt>
 <dd>
-The source code control system establishes the provenance of each line of code in a reliable way, based on strong authentication of the 
+The source code control system establishes the provenance of each line of code in a reliable way, based on strong authentication of the
 committer. When third parties contribute code, commit messages provide reliable information about the code provenance.
-<sup><a href="#fnref-1a581282a720702d3a9e11f81f8c9eeddbee55a9" id="fndef-1a581282a720702d3a9e11f81f8c9eeddbee55a9-1">2</a></sup> 
+<sup><a href="#fnref-1a581282a720702d3a9e11f81f8c9eeddbee55a9" id="fndef-1a581282a720702d3a9e11f81f8c9eeddbee55a9-1">2</a></sup>
 </dd>
-
 </dl>
 
 ## Licenses and Copyright
@@ -69,36 +68,35 @@ committer. When third parties contribute code, commit messages provide reliable 
 <dt id="LC20">LC20</dt>
 <dd>
 Libraries that are mandatory dependencies of the project's code do not create more restrictions than the Apache License does.
-<sup><a href="#fnref-76d333d056757395d9b6eb1d62e91a57dad757fa" id="fndef-76d333d056757395d9b6eb1d62e91a57dad757fa-2">3</a></sup> 
-<sup><a href="#fnref-3e4d977daeeb59a808fb0c40477b2cd50e913f2e" id="fndef-3e4d977daeeb59a808fb0c40477b2cd50e913f2e-3">4</a></sup> 
+<sup><a href="#fnref-76d333d056757395d9b6eb1d62e91a57dad757fa" id="fndef-76d333d056757395d9b6eb1d62e91a57dad757fa-2">3</a></sup>
+<sup><a href="#fnref-3e4d977daeeb59a808fb0c40477b2cd50e913f2e" id="fndef-3e4d977daeeb59a808fb0c40477b2cd50e913f2e-3">4</a></sup>
 </dd>
 
 <dt id="LC30">LC30</dt>
 <dd>
-The libraries mentioned in LC20 are available as Open Source software. 
+The libraries mentioned in LC20 are available as Open Source software.
 </dd>
 
 <dt id="LC40">LC40</dt>
-<dd>Committers are bound by an Individual Contributor Agreement (the <a href="https://www.apache.org/licenses/icla.txt">"Apache iCLA"</a>) that 
-defines which code they may commit and how they need to 
-identify code that is not their own. 
+<dd>Committers are bound by an Individual Contributor Agreement (the <a href="https://www.apache.org/licenses/icla.txt">"Apache iCLA"</a>) that
+defines which code they may commit and how they need to
+identify code that is not their own.
 </dd>
 
 <dt id="LC50">LC50</dt>
 <dd>
 The project clearly defines and documents the copyright ownership of everything that the project produces.
-<sup><a href="#fnref-258df7a61c975c67bbef17d3cf7851bafd40b8fb" id="fndef-258df7a61c975c67bbef17d3cf7851bafd40b8fb-4">5</a></sup>  
+<sup><a href="#fnref-258df7a61c975c67bbef17d3cf7851bafd40b8fb" id="fndef-258df7a61c975c67bbef17d3cf7851bafd40b8fb-4">5</a></sup>
 </dd>
-
 </dl>
 
 ## Releases
-<dl>
 
+<dl>
 <dt id="RE10">RE10</dt>
-<dd>Releases consist of source code, distributed using standard and open archive 
+<dd>Releases consist of source code, distributed using standard and open archive
 formats that are expected to stay readable in the long term.
-<sup><a href="#fnref-d2389850862fcc9bddabb3c2e23b13922d68e3fc" id="fndef-d2389850862fcc9bddabb3c2e23b13922d68e3fc-5">6</a></sup> 
+<sup><a href="#fnref-d2389850862fcc9bddabb3c2e23b13922d68e3fc" id="fndef-d2389850862fcc9bddabb3c2e23b13922d68e3fc-5">6</a></sup>
 </dd>
 
 <dt id="RE20">RE20</dt>
@@ -120,67 +118,64 @@ Releases are signed and/or distributed along with digests that anyone can reliab
 someone new to the project can independently generate the complete
 set of artifacts required for a release.
 </dd>
-
 </dl>
 
-
 ## Quality
-<dl>
 
+<dl>
 <dt id="QU10">QU10</dt>
-<dd>The 
+<dd>The
 project is open and honest about the quality of its code. Various levels
- of quality and maturity for various modules are natural and acceptable 
-as long as they are clearly communicated. 
+of quality and maturity for various modules are natural and acceptable
+as long as they are clearly communicated.
 </dd>
 
 <dt id="QU20">QU20</dt>
 <dd>
 The project puts a very high priority on producing secure software.
-<sup><a href="#fnref-89a5257606b929cc5ced2bee207c80b43541d488" id="fndef-89a5257606b929cc5ced2bee207c80b43541d488-6">7</a></sup> 
+<sup><a href="#fnref-89a5257606b929cc5ced2bee207c80b43541d488" id="fndef-89a5257606b929cc5ced2bee207c80b43541d488-6">7</a></sup>
 </dd>
 
 <dt id="QU30">QU30</dt>
 <dd>
 The project provides a well-documented, secure and private channel to report security issues, along with a documented way of responding to them.
-<sup><a href="#fnref-7c23a24b04dcf9b4b10423685fbd37f69b2b3783" id="fndef-7c23a24b04dcf9b4b10423685fbd37f69b2b3783-7">8</a></sup> 
+<sup><a href="#fnref-7c23a24b04dcf9b4b10423685fbd37f69b2b3783" id="fndef-7c23a24b04dcf9b4b10423685fbd37f69b2b3783-7">8</a></sup>
 </dd>
 
 <dt id="QU40">QU40</dt>
-<dd>The project puts a high priority on backwards compatibility and aims to document any incompatible changes and provide tools and documentation to help users transition to new features. 
- </dd>
- 
- <dt id="QU50">QU50</dt>
- <dd>
- The project strives to respond to documented bug reports in a timely manner. 
- </dd>
- </dl>
+<dd>The project puts a high priority on backwards compatibility and aims to document any incompatible changes and provide tools and documentation to help users transition to new features.
+</dd>
+
+<dt id="QU50">QU50</dt>
+<dd>
+The project strives to respond to documented bug reports in a timely manner.
+</dd>
+</dl>
 
 ## Community
 
 <dl>
-
 <dt id="CO10">CO10</dt>
 <dd>
-The project has a well-known homepage that points to all the information required to operate according to this maturity model. 
+The project has a well-known homepage that points to all the information required to operate according to this maturity model.
 </dd>
 
 <dt id="CO20">CO20</dt>
 <dd>
 The community welcomes contributions from anyone who acts in good faith and
- in a respectful manner, and who adds value to the project. 
+ in a respectful manner, and who adds value to the project.
 </dd>
- 
+
 <dt id="CO30">CO30</dt>
 <dd>
-Contributions include source code, documentation, constructive bug 
-reports, constructive discussions, marketing and generally anything that adds value to the project. 
+Contributions include source code, documentation, constructive bug
+reports, constructive discussions, marketing and generally anything that adds value to the project.
 </dd>
- 
+
 <dt id="CO40">CO40</dt>
 <dd>
-The community strives to be meritocratic and gives more rights and 
-responsibilities to contributors who, over time, add value to the project. 
+The community strives to be meritocratic and gives more rights and
+responsibilities to contributors who, over time, add value to the project.
 </dd>
 
 <dt id="CO50">CO50</dt>
@@ -191,76 +186,74 @@ access or decision power, and applies these principles consistently.
 
 <dt id="CO60">CO60</dt>
 <dd>
-The community operates based on consensus of its members (see CS10) who 
-have decision power. Dictators, benevolent or not, are not welcome in 
-Apache projects. 
+The community operates based on consensus of its members (see CS10) who
+have decision power. Dictators, benevolent or not, are not welcome in
+Apache projects.
 </dd>
 
 <dt id="CO70">CO70</dt>
 <dd>
 The project strives to answer user questions in a timely manner.
 </dd>
-
 </dl>
 
 ## Consensus Building
+
+<dl>
 <dt id="CS10">CS10</dt>
-<dd>The 
-project maintains a public list of its contributors who have decision 
+<dd>The
+project maintains a public list of its contributors who have decision
 power. The project's PMC (Project Management Committee) consists of
-those contributors. 
+those contributors.
 </dd>
 
 <dt id="CS20">CS20</dt>
 <dd>
 Decisions require a consensus among PMC members
 <sup><a href="#fnref-08fda1a3461c11086b8542178f35e0c27a4a46c3" id="fndef-08fda1a3461c11086b8542178f35e0c27a4a46c3-8">9</a></sup>
- and are documented on the project's main communications channel. 
+ and are documented on the project's main communications channel.
 The PMC takes community opinions into account, but the PMC has the final word.
  </dd>
- 
+
  <dt id="CS30">CS30</dt>
  <dd>
  The project uses documented voting rules to build consensus when discussion is not sufficient.
- <sup><a href="#fnref-9b0cf71f04bcd81dddbf6199f1c771e27566611e" id="fndef-9b0cf71f04bcd81dddbf6199f1c771e27566611e-9">10</a></sup> 
+ <sup><a href="#fnref-9b0cf71f04bcd81dddbf6199f1c771e27566611e" id="fndef-9b0cf71f04bcd81dddbf6199f1c771e27566611e-9">10</a></sup>
  </dd>
- 
+
  <dt id="CS40">CS40</dt>
  <dd>In Apache projects, vetoes are only valid for code commits. The person exercising the veto must justify it with a technical explanation, as per the Apache voting rules
-defined in CS30. 
+defined in CS30.
 </dd>
 
 <dt id="CS50">CS50</dt>
 <dd>
-All "important" discussions happen asynchronously in written form on the 
+All "important" discussions happen asynchronously in written form on the
 project's main communications channel. Offline, face-to-face or private discussions
-<sup><a href="#fnref-d9e7a517f046358463f038f3830fef171e69f78b" id="fndef-d9e7a517f046358463f038f3830fef171e69f78b-10">11</a></sup> 
-that affect the project are also documented on that channel. 
+<sup><a href="#fnref-d9e7a517f046358463f038f3830fef171e69f78b" id="fndef-d9e7a517f046358463f038f3830fef171e69f78b-10">11</a></sup>
+that affect the project are also documented on that channel.
 </dd>
-
 </dl>
 
 ## Independence
 
 <dl>
-
 <dt id="IN10">IN10</dt>
 <dd>
 The project is independent from any corporate or organizational influence.
-<sup><a href="#fnref-764b2c2fd32deb4ff73ea01efa67c8556303c359" id="fndef-764b2c2fd32deb4ff73ea01efa67c8556303c359-11">12</a></sup> 
+<sup><a href="#fnref-764b2c2fd32deb4ff73ea01efa67c8556303c359" id="fndef-764b2c2fd32deb4ff73ea01efa67c8556303c359-11">12</a></sup>
 </dd>
 
 <dt id="IN20">IN20</dt>
 <dd>Contributors act as themselves, not as representatives of a corporation or organization.
 </dd>
-
 </dl>
 
 # How To Use The Apache Project Maturity Model
 
 **Remember:** This model is a guide; it is not a requirements document. The model shows what generally good behaviors in an Apache project look like.
 
-So far, inside the ASF, podlings preparing their graduation 
+So far, inside the ASF, podlings preparing their graduation
 from the [Apache Incubator](https://incubator.apache.org) have used this model, mostly for self-assessment.
 
 It might be useful for top-level ASF projects to regularly assess their maturity based on this model, but this is not a requirement at this time.
@@ -286,13 +279,13 @@ See [https://s.apache.org/apache_maturity_model](https://s.apache.org/apache_mat
 
 ## Status / Document Version
 
-v 1.0, February 2015, defined by consensus by Apache Community Development project.
+v1.0, February 2015, defined by consensus by Apache Community Development project.
 
-v 1.1, October 2016 added RE50.
+v1.1, October 2016 added RE50.
 
-v 1.2, February 2018, reworked the "how to use" section with more links to self-assessments.
+v1.2, February 2018, reworked the "how to use" section with more links to self-assessments.
 
-v 1.3, June 2021, improve readability and simplify the language where possible.
+v1.3, June 2021, improve readability and simplify the language where possible.
 
 See the <a href="https://svn.apache.org/viewvc/comdev/site/trunk/content/apache-way/apache-project-maturity-model.mdtext?view=log" target="_blank">svn revision history</a> (for older
 versions) and <a href="https://github.com/apache/comdev-site/commits/main/source/apache-way/apache-project-maturity-model.md">GitHub history</a> (since March 2020) of this document for more details and other minor changes.
@@ -303,82 +296,82 @@ versions) and <a href="https://github.com/apache/comdev-site/commits/main/source
 
 <li>
 <a id="fnref-a2e0cd066fd8f45af4e87bcdbf8d9abd3ad40872"></a>
-"For distribution to the public at no charge" is straight from the from the ASF Bylaws at <a class="http" href="https://apache.org/foundation/bylaws.html" target="_blank">https://apache.org/foundation/bylaws.html</a>.  
+"For distribution to the public at no charge" is straight from the from the ASF Bylaws at <a class="http" href="https://apache.org/foundation/bylaws.html" target="_blank">https://apache.org/foundation/bylaws.html</a>.
 
 (<a href="#fndef-a2e0cd066fd8f45af4e87bcdbf8d9abd3ad40872-0">1</a>)
 </li>
 
 <li>
 <a id="fndef-1a581282a720702d3a9e11f81f8c9eeddbee55a9-1"></a>
-See also LC40.  
+See also LC40.
 
 (<a href="#fndef-1a581282a720702d3a9e11f81f8c9eeddbee55a9-1">2</a>)
 </li>
 
 <li>
 <a id="fnref-76d333d056757395d9b6eb1d62e91a57dad757fa"></a>
-It's ok for platforms (like a runtime used to execute our code) to have  different licenses as long as they don't impose reciprocal licensing on 
-what we are distributing.  
+It's ok for platforms (like a runtime used to execute our code) to have  different licenses as long as they don't impose reciprocal licensing on
+what we are distributing.
 
 (<a href="#fndef-76d333d056757395d9b6eb1d62e91a57dad757fa-2">3</a>)
 </li>
 
 <li>
 <a id="fnref-3e4d977daeeb59a808fb0c40477b2cd50e913f2e"></a>
-<a class="http" href="https://apache.org/legal/resolved.html">https://apache.org/legal/resolved.html</a> has information about acceptable licenses for third-party dependencies.  
+<a class="http" href="https://apache.org/legal/resolved.html">https://apache.org/legal/resolved.html</a> has information about acceptable licenses for third-party dependencies.
 
 (<a href="#fndef-3e4d977daeeb59a808fb0c40477b2cd50e913f2e-3">4</a>)
 </li>
 
 <li>
 <a id="fnref-258df7a61c975c67bbef17d3cf7851bafd40b8fb"></a>
-In Apache projects, the ASF owns the copyright for the collective work, 
-i.e. the project's releases. Contributors retain copyright on their 
-contributions but grant the ASF a perpetual copyright license for them. 
+In Apache projects, the ASF owns the copyright for the collective work,
+i.e. the project's releases. Contributors retain copyright on their
+contributions but grant the ASF a perpetual copyright license for them.
 
 (<a href="#fndef-258df7a61c975c67bbef17d3cf7851bafd40b8fb-4">5</a>)
 </li>
- 
+
  <li>
  <a id="fnref-d2389850862fcc9bddabb3c2e23b13922d68e3fc"></a>
- See <a class="http" href="https://www.apache.org/legal/release-policy.html">https://www.apache.org/legal/release-policy.html</a> for more info on Apache releases.  
- 
+ See <a class="http" href="https://www.apache.org/legal/release-policy.html">https://www.apache.org/legal/release-policy.html</a> for more info on Apache releases.
+
  (<a href="#fndef-d2389850862fcc9bddabb3c2e23b13922d68e3fc-5">6</a>)
  </li>
- 
+
  <li>
  <a id="fnref-89a5257606b929cc5ced2bee207c80b43541d488"></a>
- The required level of security depends on the software's intended uses, of course. Projects should clearly document security expectations.  
- 
+ The required level of security depends on the software's intended uses, of course. Projects should clearly document security expectations.
+
  (<a href="#fndef-89a5257606b929cc5ced2bee207c80b43541d488-6">7</a>)
  </li>
- 
+
  <li>
  <a id="fnref-7c23a24b04dcf9b4b10423685fbd37f69b2b3783"></a>
- Apache projects can just point to <a class="http" href="https://www.apache.org/security/">https://www.apache.org/security/</a> or use their own security contacts page, which should also point to that.  
- 
+ Apache projects can just point to <a class="http" href="https://www.apache.org/security/">https://www.apache.org/security/</a> or use their own security contacts page, which should also point to that.
+
  (<a href="#fndef-7c23a24b04dcf9b4b10423685fbd37f69b2b3783-7">8</a>)
  </li>
- 
+
  <li>
  <a id="fnref-08fda1a3461c11086b8542178f35e0c27a4a46c3"></a>
- In Apache projects, "consensus" means <em>widespread agreement among people who have decision power</em>. It does not necessarily mean "unanimity".  
- 
+ In Apache projects, "consensus" means <em>widespread agreement among people who have decision power</em>. It does not necessarily mean "unanimity".
+
  (<a href="#fndef-08fda1a3461c11086b8542178f35e0c27a4a46c3-8">9</a>)
  </li>
- 
+
  <li>
  <a id="fnref-9b0cf71f04bcd81dddbf6199f1c771e27566611e"></a>
- For Apache projects, <a class="http" href="https://www.apache.org/foundation/voting.html" target="_blank">https://www.apache.org/foundation/voting.html</a> defines the voting rules.  
- 
+ For Apache projects, <a class="http" href="https://www.apache.org/foundation/voting.html" target="_blank">https://www.apache.org/foundation/voting.html</a> defines the voting rules.
+
  (<a href="#fndef-9b0cf71f04bcd81dddbf6199f1c771e27566611e-9">10</a>)
  </li>
- 
+
  <li>
  <a id="fnref-d9e7a517f046358463f038f3830fef171e69f78b"></a>
-Each Apache project has a private mailing list that its PMC is expected to use 
-only when really needed. The private list is typically used for 
-discussions about people, for example to discuss and to vote on PMC 
+Each Apache project has a private mailing list that its PMC is expected to use
+only when really needed. The private list is typically used for
+discussions about people, for example to discuss and to vote on PMC
 and committer candidates.
 
 (<a href="#fndef-d9e7a517f046358463f038f3830fef171e69f78b-10">11</a>)
@@ -386,10 +379,10 @@ and committer candidates.
 
 <li>
 <a id="fnref-764b2c2fd32deb4ff73ea01efa67c8556303c359"></a>
-Independence can be understood as basing the project's decisions on the open 
-discussions that happen on the project's main communications channel, 
+Independence can be understood as basing the project's decisions on the open
+discussions that happen on the project's main communications channel,
 with no hidden agendas.
-  
+
 (<a href="#fndef-764b2c2fd32deb4ff73ea01efa67c8556303c359-11">12</a>)
 </li>
 

--- a/source/apache-way/apache-project-maturity-model.md
+++ b/source/apache-way/apache-project-maturity-model.md
@@ -221,9 +221,9 @@ name consistently, with appropriate [trademark attributions][trademark-attributi
 
 <dt id="TB20">TB20</dt>
 <dd>
-The project's primary homepage is at `projectname.apache.org`.
+The project's primary homepage is at <code>projectname.apache.org</code>.
 When exceptions exist to use alternate domains for any purpose, any
-`non-apache.org` domain names are owned by the ASF.
+<code>non-apache.org</code> domain names are owned by the ASF.
 </dd>
 
 <dt id="TB30">TB30</dt>
@@ -231,7 +231,8 @@ When exceptions exist to use alternate domains for any purpose, any
 The ASF has trademark rights, including any registrations, to the
 project name, logo, and any other major branding elements.
 
-NB. For example, any transfers of existing trademark registrations
+<br/><br/>
+<em>NB.</em> For example, any transfers of existing trademark registrations
 during Incubation must completed before graduation.
 </dd>
 
@@ -241,7 +242,8 @@ The project monitors for any major misuses of their project's brand
 by others, and [reports][reports-trademark-issues] any potential
 misuses to Brand Management.
 
-NB. TB40 is a balancing act: we hope that PMCs are spending some
+<br/><br/>
+<em>NB.</em> TB40 is a balancing act: we hope that PMCs are spending some
 time responding to any obvious or blatant misuses of their brand.
 But PMCs sometimes can't handle all the details of actually stopping a
 potential infringement; what we really need is for PMCs to actively
@@ -342,7 +344,7 @@ v1.2, February 2018, reworked the "how to use" section with more links to self-a
 
 v1.3, June 2021, improve readability and simplify the language where possible.
 
-v1.4, December 2024, added the Trademark and Branding section (TB10-TB50).
+v1.4, December 2024, added the Trademark and Branding section (TB10-TB40).
 
 See the <a href="https://svn.apache.org/viewvc/comdev/site/trunk/content/apache-way/apache-project-maturity-model.mdtext?view=log" target="_blank">svn revision history</a> (for older
 versions) and <a href="https://github.com/apache/comdev-site/commits/main/source/apache-way/apache-project-maturity-model.md">GitHub history</a> (since March 2020) of this document for more details and other minor changes.


### PR DESCRIPTION
Per discussion at https://lists.apache.org/thread/8q3w4osqflyjjp05j4ddgwkcwh12617l.

You can review ignore the first auto format commits

You can preview the page at https://community-maturity-model-tb.staged.apache.org/ (seems not staged yet), or run `hugo server` locally for preview.