### PR TITLE
Clarify the terminology: PMC and PMC Member

### DIFF
--- a/source/contributor-ladder.md
+++ b/source/contributor-ladder.md
@@ -91,7 +91,7 @@ Note that the term _PMC_ refers to the _group_ that steers a project.
 
 The _people_ who are members of the group are called _PMC Members_.
 
-Referring to those people as _PMCs_ is incorrect and can be confusing,
+Referring to those people as _PMCs_ is incorrect and can be confusing;
 please avoid doing that.
 
 ## Foundation Member

--- a/source/contributor-ladder.md
+++ b/source/contributor-ladder.md
@@ -83,8 +83,16 @@ developer mailing list(s), in the view of the entire community. A PMC
 also has a private mailing list, which is for discussion of topics such
 as the addition of new committers and PMC members, and any other
 sensitive topics.
-
 [See more information about being a PMC member](/pmc/).
+
+### Terminology: PMC and PMC Member
+
+Note that the term _PMC_ refers to the _group_ that steers a project.
+
+The _people_ who are members of the group are called _PMC Members_.
+
+Referring to those people as _PMCs_ is incorrect and can be confusing,
+please avoid doing that.
 
 ## Foundation Member
 


### PR DESCRIPTION
Provides an URL to point people to when they use "PMC" to mean "PMC Member".

Preview should be at https://community-pmc-members.staged.apache.org/ but I get a 404 for that right now, opened https://issues.apache.org/jira/browse/INFRA-26845 about it.